### PR TITLE
Add DbContext and Identity entities

### DIFF
--- a/Server.Api/Server.Api/Data/ApplicationDbContext.cs
+++ b/Server.Api/Server.Api/Data/ApplicationDbContext.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Server.Api.Entities;
+
+namespace Server.Api.Data;
+
+public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Department> Departments { get; set; } = default!;
+}

--- a/Server.Api/Server.Api/Entities/ApplicationUser.cs
+++ b/Server.Api/Server.Api/Entities/ApplicationUser.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace Server.Api.Entities;
+
+public class ApplicationUser : IdentityUser
+{
+    public Guid? DepartmentId { get; set; }
+    public Department? Department { get; set; }
+}

--- a/Server.Api/Server.Api/Entities/Department.cs
+++ b/Server.Api/Server.Api/Entities/Department.cs
@@ -1,0 +1,8 @@
+namespace Server.Api.Entities;
+
+public class Department
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public ICollection<ApplicationUser> Users { get; set; } = new List<ApplicationUser>();
+}


### PR DESCRIPTION
## Summary
- add `ApplicationDbContext` with identity support
- introduce `ApplicationUser` and `Department` entities

## Testing
- `dotnet --list-sdks`


------
https://chatgpt.com/codex/tasks/task_e_6849b436f1ac832390c52776d69663ac