### PR TITLE
Add service interface definitions

### DIFF
--- a/Server.Api/Server.Api/Interfaces/IApplicationService.cs
+++ b/Server.Api/Server.Api/Interfaces/IApplicationService.cs
@@ -1,0 +1,3 @@
+namespace GovServices.Server.Interfaces;
+
+public interface IApplicationService { }

--- a/Server.Api/Server.Api/Interfaces/IAuditService.cs
+++ b/Server.Api/Server.Api/Interfaces/IAuditService.cs
@@ -1,0 +1,3 @@
+namespace GovServices.Server.Interfaces;
+
+public interface IAuditService { }

--- a/Server.Api/Server.Api/Interfaces/IAuthService.cs
+++ b/Server.Api/Server.Api/Interfaces/IAuthService.cs
@@ -1,0 +1,3 @@
+namespace GovServices.Server.Interfaces;
+
+public interface IAuthService { }

--- a/Server.Api/Server.Api/Interfaces/IDocumentService.cs
+++ b/Server.Api/Server.Api/Interfaces/IDocumentService.cs
@@ -1,0 +1,3 @@
+namespace GovServices.Server.Interfaces;
+
+public interface IDocumentService { }

--- a/Server.Api/Server.Api/Interfaces/IEcpService.cs
+++ b/Server.Api/Server.Api/Interfaces/IEcpService.cs
@@ -1,0 +1,3 @@
+namespace GovServices.Server.Interfaces;
+
+public interface IEcpService { }

--- a/Server.Api/Server.Api/Interfaces/IEmailService.cs
+++ b/Server.Api/Server.Api/Interfaces/IEmailService.cs
@@ -1,0 +1,3 @@
+namespace GovServices.Server.Interfaces;
+
+public interface IEmailService { }

--- a/Server.Api/Server.Api/Interfaces/IGeoService.cs
+++ b/Server.Api/Server.Api/Interfaces/IGeoService.cs
@@ -1,0 +1,3 @@
+namespace GovServices.Server.Interfaces;
+
+public interface IGeoService { }

--- a/Server.Api/Server.Api/Interfaces/IOcrService.cs
+++ b/Server.Api/Server.Api/Interfaces/IOcrService.cs
@@ -1,0 +1,3 @@
+namespace GovServices.Server.Interfaces;
+
+public interface IOcrService { }

--- a/Server.Api/Server.Api/Interfaces/IOrderService.cs
+++ b/Server.Api/Server.Api/Interfaces/IOrderService.cs
@@ -1,0 +1,3 @@
+namespace GovServices.Server.Interfaces;
+
+public interface IOrderService { }

--- a/Server.Api/Server.Api/Interfaces/IOutgoingService.cs
+++ b/Server.Api/Server.Api/Interfaces/IOutgoingService.cs
@@ -1,0 +1,3 @@
+namespace GovServices.Server.Interfaces;
+
+public interface IOutgoingService { }

--- a/Server.Api/Server.Api/Interfaces/IRosreestrIntegrationService.cs
+++ b/Server.Api/Server.Api/Interfaces/IRosreestrIntegrationService.cs
@@ -1,0 +1,3 @@
+namespace GovServices.Server.Interfaces;
+
+public interface IRosreestrIntegrationService { }

--- a/Server.Api/Server.Api/Interfaces/ISedIntegrationService.cs
+++ b/Server.Api/Server.Api/Interfaces/ISedIntegrationService.cs
@@ -1,0 +1,3 @@
+namespace GovServices.Server.Interfaces;
+
+public interface ISedIntegrationService { }

--- a/Server.Api/Server.Api/Interfaces/IServiceService.cs
+++ b/Server.Api/Server.Api/Interfaces/IServiceService.cs
@@ -1,0 +1,3 @@
+namespace GovServices.Server.Interfaces;
+
+public interface IServiceService { }

--- a/Server.Api/Server.Api/Interfaces/ITemplateService.cs
+++ b/Server.Api/Server.Api/Interfaces/ITemplateService.cs
@@ -1,0 +1,3 @@
+namespace GovServices.Server.Interfaces;
+
+public interface ITemplateService { }

--- a/Server.Api/Server.Api/Interfaces/IUserService.cs
+++ b/Server.Api/Server.Api/Interfaces/IUserService.cs
@@ -1,0 +1,3 @@
+namespace GovServices.Server.Interfaces;
+
+public interface IUserService { }

--- a/Server.Api/Server.Api/Interfaces/IWorkflowService.cs
+++ b/Server.Api/Server.Api/Interfaces/IWorkflowService.cs
@@ -1,0 +1,3 @@
+namespace GovServices.Server.Interfaces;
+
+public interface IWorkflowService { }


### PR DESCRIPTION
## Summary
- define service interfaces for upcoming services
- each interface lives in `Server.Api/Server.Api/Interfaces`

## Testing
- `dotnet build GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_6849c5d6074083238f8ca67204b858a4