### PR TITLE
Add API controllers skeleton

### DIFF
--- a/Server.Api/Server.Api/Controllers/ApplicationsController.cs
+++ b/Server.Api/Server.Api/Controllers/ApplicationsController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ApplicationsController : ControllerBase
+{
+    private readonly IApplicationService _applications;
+
+    public ApplicationsController(IApplicationService applications)
+    {
+        _applications = applications;
+    }
+
+    [HttpGet]
+    public IActionResult GetAll()
+    {
+        return Ok();
+    }
+}

--- a/Server.Api/Server.Api/Controllers/AuthController.cs
+++ b/Server.Api/Server.Api/Controllers/AuthController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController : ControllerBase
+{
+    private readonly IAuthService _auth;
+
+    public AuthController(IAuthService auth)
+    {
+        _auth = auth;
+    }
+
+    [HttpPost("login")]
+    public IActionResult Login()
+    {
+        return Ok();
+    }
+}

--- a/Server.Api/Server.Api/Controllers/DocumentsController.cs
+++ b/Server.Api/Server.Api/Controllers/DocumentsController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class DocumentsController : ControllerBase
+{
+    private readonly IDocumentService _documents;
+
+    public DocumentsController(IDocumentService documents)
+    {
+        _documents = documents;
+    }
+
+    [HttpGet]
+    public IActionResult GetAll()
+    {
+        return Ok();
+    }
+}

--- a/Server.Api/Server.Api/Controllers/GeoObjectsController.cs
+++ b/Server.Api/Server.Api/Controllers/GeoObjectsController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class GeoObjectsController : ControllerBase
+{
+    private readonly IGeoService _geo;
+
+    public GeoObjectsController(IGeoService geo)
+    {
+        _geo = geo;
+    }
+
+    [HttpGet]
+    public IActionResult GetAll()
+    {
+        return Ok();
+    }
+}

--- a/Server.Api/Server.Api/Controllers/Integrations/EcpController.cs
+++ b/Server.Api/Server.Api/Controllers/Integrations/EcpController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+
+namespace GovServices.Server.Controllers.Integrations;
+
+[ApiController]
+[Route("api/integrations/[controller]")]
+public class EcpController : ControllerBase
+{
+    private readonly IEcpService _ecp;
+
+    public EcpController(IEcpService ecp)
+    {
+        _ecp = ecp;
+    }
+
+    [HttpGet]
+    public IActionResult GetAll()
+    {
+        return Ok();
+    }
+}

--- a/Server.Api/Server.Api/Controllers/Integrations/RosreestrController.cs
+++ b/Server.Api/Server.Api/Controllers/Integrations/RosreestrController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+
+namespace GovServices.Server.Controllers.Integrations;
+
+[ApiController]
+[Route("api/integrations/[controller]")]
+public class RosreestrController : ControllerBase
+{
+    private readonly IRosreestrIntegrationService _rosreestr;
+
+    public RosreestrController(IRosreestrIntegrationService rosreestr)
+    {
+        _rosreestr = rosreestr;
+    }
+
+    [HttpGet]
+    public IActionResult GetAll()
+    {
+        return Ok();
+    }
+}

--- a/Server.Api/Server.Api/Controllers/Integrations/SedController.cs
+++ b/Server.Api/Server.Api/Controllers/Integrations/SedController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+
+namespace GovServices.Server.Controllers.Integrations;
+
+[ApiController]
+[Route("api/integrations/[controller]")]
+public class SedController : ControllerBase
+{
+    private readonly ISedIntegrationService _sed;
+
+    public SedController(ISedIntegrationService sed)
+    {
+        _sed = sed;
+    }
+
+    [HttpGet]
+    public IActionResult GetAll()
+    {
+        return Ok();
+    }
+}

--- a/Server.Api/Server.Api/Controllers/OrdersController.cs
+++ b/Server.Api/Server.Api/Controllers/OrdersController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class OrdersController : ControllerBase
+{
+    private readonly IOrderService _orders;
+
+    public OrdersController(IOrderService orders)
+    {
+        _orders = orders;
+    }
+
+    [HttpGet]
+    public IActionResult GetAll()
+    {
+        return Ok();
+    }
+}

--- a/Server.Api/Server.Api/Controllers/OutgoingController.cs
+++ b/Server.Api/Server.Api/Controllers/OutgoingController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class OutgoingController : ControllerBase
+{
+    private readonly IOutgoingService _outgoing;
+
+    public OutgoingController(IOutgoingService outgoing)
+    {
+        _outgoing = outgoing;
+    }
+
+    [HttpGet]
+    public IActionResult GetAll()
+    {
+        return Ok();
+    }
+}

--- a/Server.Api/Server.Api/Controllers/ServicesController.cs
+++ b/Server.Api/Server.Api/Controllers/ServicesController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ServicesController : ControllerBase
+{
+    private readonly IServiceService _services;
+
+    public ServicesController(IServiceService services)
+    {
+        _services = services;
+    }
+
+    [HttpGet]
+    public IActionResult GetAll()
+    {
+        return Ok();
+    }
+}

--- a/Server.Api/Server.Api/Controllers/TemplatesController.cs
+++ b/Server.Api/Server.Api/Controllers/TemplatesController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class TemplatesController : ControllerBase
+{
+    private readonly ITemplateService _templates;
+
+    public TemplatesController(ITemplateService templates)
+    {
+        _templates = templates;
+    }
+
+    [HttpGet]
+    public IActionResult GetAll()
+    {
+        return Ok();
+    }
+}

--- a/Server.Api/Server.Api/Controllers/UsersController.cs
+++ b/Server.Api/Server.Api/Controllers/UsersController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class UsersController : ControllerBase
+{
+    private readonly IUserService _users;
+
+    public UsersController(IUserService users)
+    {
+        _users = users;
+    }
+
+    [HttpGet]
+    public IActionResult GetAll()
+    {
+        return Ok();
+    }
+}

--- a/Server.Api/Server.Api/Controllers/WorkflowController.cs
+++ b/Server.Api/Server.Api/Controllers/WorkflowController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class WorkflowController : ControllerBase
+{
+    private readonly IWorkflowService _workflows;
+
+    public WorkflowController(IWorkflowService workflows)
+    {
+        _workflows = workflows;
+    }
+
+    [HttpPost("advance")]
+    public IActionResult Advance()
+    {
+        return Ok();
+    }
+}


### PR DESCRIPTION
## Summary
- add skeleton API controllers for core entities and integration services
- ensure .NET 8 and .NET 9 SDKs installed for build

## Testing
- `dotnet build Server.Api/Server.Api/Server.Api.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6849d937e8d48323afa747592ce6a4b1