### PR TITLE
Implement TemplateService with PDF generation

### DIFF
--- a/Server.Api/Server.Api/Data/ApplicationDbContext.cs
+++ b/Server.Api/Server.Api/Data/ApplicationDbContext.cs
@@ -11,4 +11,5 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     }
 
     public DbSet<Department> Departments { get; set; } = default!;
+    public DbSet<Template> Templates { get; set; } = default!;
 }

--- a/Server.Api/Server.Api/Interfaces/ITemplateService.cs
+++ b/Server.Api/Server.Api/Interfaces/ITemplateService.cs
@@ -1,3 +1,14 @@
 namespace GovServices.Server.Interfaces;
 
-public interface ITemplateService { }
+using GovServices.Server.DTOs;
+using GovServices.Server.Models;
+
+public interface ITemplateService
+{
+    Task<List<TemplateDto>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<TemplateDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<TemplateDto> CreateAsync(CreateTemplateDto dto, CancellationToken cancellationToken = default);
+    Task<bool> UpdateAsync(int id, CreateTemplateDto dto, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default);
+    Task<byte[]> GeneratePdfAsync(int templateId, TemplateModel model, CancellationToken cancellationToken = default);
+}

--- a/Server.Api/Server.Api/Program.cs
+++ b/Server.Api/Server.Api/Program.cs
@@ -73,6 +73,7 @@ builder.Services.AddSwaggerGen(c =>
 
 // DI for services
 builder.Services.AddScoped<IExampleService, ExampleService>();
+builder.Services.AddScoped<ITemplateService, TemplateService>();
 
 // Middleware Audit
 builder.Services.AddScoped<AuditMiddleware>();

--- a/Server.Api/Server.Api/Server.Api.csproj
+++ b/Server.Api/Server.Api/Server.Api.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="2.4.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0" />
+    <PackageReference Include="RazorLight" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Server.Api/Server.Api/Services/TemplateService.cs
+++ b/Server.Api/Server.Api/Services/TemplateService.cs
@@ -1,7 +1,0 @@
-using GovServices.Server.Interfaces;
-
-namespace GovServices.Server.Services;
-
-public class TemplateService : ITemplateService
-{
-}

--- a/Server.Api/Server.Api/Services/Templates/TemplateService.cs
+++ b/Server.Api/Server.Api/Services/Templates/TemplateService.cs
@@ -1,0 +1,116 @@
+using AutoMapper;
+using DinkToPdf;
+using DinkToPdf.Contracts;
+using GovServices.Server.Data;
+using GovServices.Server.DTOs;
+using GovServices.Server.Entities;
+using GovServices.Server.Interfaces;
+using GovServices.Server.Models;
+using Microsoft.EntityFrameworkCore;
+using RazorLight;
+
+namespace GovServices.Server.Services;
+
+public class TemplateService : ITemplateService
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IMapper _mapper;
+    private readonly IConverter _pdfConverter;
+    private readonly RazorLightEngine _razorEngine;
+
+    public TemplateService(ApplicationDbContext db, IMapper mapper, IConverter pdfConverter)
+    {
+        _db = db;
+        _mapper = mapper;
+        _pdfConverter = pdfConverter;
+        _razorEngine = new RazorLightEngineBuilder()
+            .UseMemoryCachingProvider()
+            .Build();
+    }
+
+    public async Task<List<TemplateDto>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var templates = await _db.Set<Template>()
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+        return _mapper.Map<List<TemplateDto>>(templates);
+    }
+
+    public async Task<TemplateDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var template = await _db.Set<Template>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+        return template == null ? null : _mapper.Map<TemplateDto>(template);
+    }
+
+    public async Task<TemplateDto> CreateAsync(CreateTemplateDto dto, CancellationToken cancellationToken = default)
+    {
+        var entity = new Template
+        {
+            Name = dto.Name,
+            Type = dto.Type,
+            Content = dto.Content
+        };
+
+        _db.Set<Template>().Add(entity);
+        await _db.SaveChangesAsync(cancellationToken);
+        return _mapper.Map<TemplateDto>(entity);
+    }
+
+    public async Task<bool> UpdateAsync(int id, CreateTemplateDto dto, CancellationToken cancellationToken = default)
+    {
+        var entity = await _db.Set<Template>().FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+        if (entity == null)
+            return false;
+
+        entity.Name = dto.Name;
+        entity.Type = dto.Type;
+        entity.Content = dto.Content;
+        await _db.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    public async Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var entity = await _db.Set<Template>().FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+        if (entity == null)
+            return false;
+
+        _db.Remove(entity);
+        await _db.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    public async Task<byte[]> GeneratePdfAsync(int templateId, TemplateModel model, CancellationToken cancellationToken = default)
+    {
+        var template = await _db.Set<Template>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == templateId, cancellationToken);
+        if (template == null)
+            throw new InvalidOperationException($"Template with id {templateId} not found");
+
+        var html = await _razorEngine.CompileRenderStringAsync($"tmpl_{templateId}", template.Content, model);
+
+        var doc = new HtmlToPdfDocument
+        {
+            GlobalSettings = new GlobalSettings
+            {
+                PaperSize = PaperKind.A4,
+                Orientation = Orientation.Portrait,
+                ColorMode = ColorMode.Color
+            },
+            Objects =
+            {
+                new ObjectSettings
+                {
+                    HtmlContent = html,
+                    WebSettings = { DefaultEncoding = "utf-8" }
+                }
+            }
+        };
+
+        var bytes = _pdfConverter.Convert(doc);
+        return bytes;
+    }
+}


### PR DESCRIPTION
## Summary
- create TemplateService in a dedicated folder and implement CRUD
- build RazorLight engine for rendering
- add PDF generation with DinkToPdf
- define ITemplateService interface
- register service in DI and add DbSet
- include RazorLight package

## Testing
- `dotnet restore`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6849da2a39748323971b0a89a8b1287c