### PR TITLE
Implement OCR service

### DIFF
--- a/Server.Api/Server.Api/Interfaces/IOcrService.cs
+++ b/Server.Api/Server.Api/Interfaces/IOcrService.cs
@@ -1,3 +1,6 @@
 namespace GovServices.Server.Interfaces;
 
-public interface IOcrService { }
+public interface IOcrService
+{
+    Task<string> RecognizeAsync(string filePath);
+}

--- a/Server.Api/Server.Api/Services/OCR/OcrService.cs
+++ b/Server.Api/Server.Api/Services/OCR/OcrService.cs
@@ -1,0 +1,18 @@
+using GovServices.Server.Interfaces;
+using Tesseract;
+
+namespace GovServices.Server.Services;
+
+public class OcrService : IOcrService
+{
+    public async Task<string> RecognizeAsync(string filePath)
+    {
+        return await Task.Run(() =>
+        {
+            using var engine = new TesseractEngine("./tessdata", "rus", EngineMode.Default);
+            using var img = Pix.LoadFromFile(filePath);
+            using var page = engine.Process(img);
+            return page.GetText();
+        });
+    }
+}

--- a/Server.Api/Server.Api/Services/OcrService.cs
+++ b/Server.Api/Server.Api/Services/OcrService.cs
@@ -1,7 +1,0 @@
-using GovServices.Server.Interfaces;
-
-namespace GovServices.Server.Services;
-
-public class OcrService : IOcrService
-{
-}


### PR DESCRIPTION
## Summary
- implement `RecognizeAsync` in `OcrService`
- declare `RecognizeAsync` in `IOcrService`
- move OCR service to a dedicated folder
- install .NET SDK 9 and 8 for building

## Testing
- `dotnet build GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_6849da5696788323a372c992317557d4