### PR TITLE
Implement EcpService skeleton

### DIFF
--- a/Server.Api/Server.Api/Interfaces/IEcpService.cs
+++ b/Server.Api/Server.Api/Interfaces/IEcpService.cs
@@ -1,3 +1,7 @@
 namespace GovServices.Server.Interfaces;
 
-public interface IEcpService { }
+public interface IEcpService
+{
+    Task<byte[]> SignPdfAsync(byte[] pdfBytes, string certificateThumbprint);
+    Task<bool> VerifySignatureAsync(byte[] signedPdfBytes);
+}

--- a/Server.Api/Server.Api/Services/EcpService.cs
+++ b/Server.Api/Server.Api/Services/EcpService.cs
@@ -1,7 +1,0 @@
-using GovServices.Server.Interfaces;
-
-namespace GovServices.Server.Services;
-
-public class EcpService : IEcpService
-{
-}

--- a/Server.Api/Server.Api/Services/Integrations/EcpService.cs
+++ b/Server.Api/Server.Api/Services/Integrations/EcpService.cs
@@ -1,0 +1,18 @@
+using GovServices.Server.Interfaces;
+
+namespace GovServices.Server.Services.Integrations;
+
+public class EcpService : IEcpService
+{
+    public async Task<byte[]> SignPdfAsync(byte[] pdfBytes, string certificateThumbprint)
+    {
+        // TODO интеграция с КриптоПро
+        return await Task.FromResult(pdfBytes);
+    }
+
+    public async Task<bool> VerifySignatureAsync(byte[] signedPdfBytes)
+    {
+        // TODO проверка
+        return await Task.FromResult(true);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `IEcpService` with methods for PDF signing and verification
- add `Services/Integrations/EcpService` with stubbed methods
- remove old empty `EcpService`
- ensure .NET 8 and 9 SDKs are installed

## Testing
- `dotnet build GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_6849da9a1e448323800060ef07268540