### PR TITLE
Implement AuditService logging

### DIFF
--- a/Server.Api/Server.Api/Data/ApplicationDbContext.cs
+++ b/Server.Api/Server.Api/Data/ApplicationDbContext.cs
@@ -11,4 +11,5 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     }
 
     public DbSet<Department> Departments { get; set; } = default!;
+    public DbSet<AuditLog> AuditLogs { get; set; } = default!;
 }

--- a/Server.Api/Server.Api/Interfaces/IAuditService.cs
+++ b/Server.Api/Server.Api/Interfaces/IAuditService.cs
@@ -1,3 +1,8 @@
+using GovServices.Server.DTOs;
+
 namespace GovServices.Server.Interfaces;
 
-public interface IAuditService { }
+public interface IAuditService
+{
+    Task LogAsync(AuditLogDto dto);
+}

--- a/Server.Api/Server.Api/Services/AuditService.cs
+++ b/Server.Api/Server.Api/Services/AuditService.cs
@@ -1,7 +1,32 @@
 using GovServices.Server.Interfaces;
+using GovServices.Server.Data;
+using GovServices.Server.DTOs;
+using GovServices.Server.Entities;
 
 namespace GovServices.Server.Services;
 
 public class AuditService : IAuditService
 {
+    private readonly ApplicationDbContext _context;
+
+    public AuditService(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task LogAsync(AuditLogDto dto)
+    {
+        var ent = new AuditLog
+        {
+            UserName = dto.UserName,
+            ActionType = dto.ActionType,
+            EntityType = dto.EntityType,
+            EntityId = dto.EntityId,
+            Timestamp = dto.Timestamp,
+            DurationMs = dto.DurationMs
+        };
+
+        _context.AuditLogs.Add(ent);
+        await _context.SaveChangesAsync();
+    }
 }


### PR DESCRIPTION
## Summary
- implement `AuditService.LogAsync` for recording audit logs
- declare `IAuditService.LogAsync`
- add `AuditLogs` DbSet to `ApplicationDbContext`

## Testing
- `dotnet build GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_6849dac1eeac8323972d69a707e10197