### PR TITLE
Implement GeoService

### DIFF
--- a/Server.Api/Server.Api/Data/ApplicationDbContext.cs
+++ b/Server.Api/Server.Api/Data/ApplicationDbContext.cs
@@ -12,4 +12,5 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 
     public DbSet<Department> Departments { get; set; } = default!;
     public DbSet<Service> Services { get; set; } = default!;
+    public DbSet<GeoObject> GeoObjects { get; set; } = default!;
 }

--- a/Server.Api/Server.Api/Interfaces/IGeoService.cs
+++ b/Server.Api/Server.Api/Interfaces/IGeoService.cs
@@ -1,3 +1,12 @@
+using GovServices.Server.DTOs;
+
 namespace GovServices.Server.Interfaces;
 
-public interface IGeoService { }
+public interface IGeoService
+{
+    Task<List<GeoObjectDto>> GetAllAsync();
+    Task<GeoObjectDto?> GetByIdAsync(int id);
+    Task<GeoObjectDto> CreateAsync(CreateGeoObjectDto dto);
+    Task<List<GeoObjectDto>> GetIntersectingAsync(string wkt);
+    Task DeleteAsync(int id);
+}

--- a/Server.Api/Server.Api/Services/GeoService.cs
+++ b/Server.Api/Server.Api/Services/GeoService.cs
@@ -1,7 +1,76 @@
+using AutoMapper;
+using GovServices.Server.Data;
+using GovServices.Server.DTOs;
+using GovServices.Server.Entities;
 using GovServices.Server.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
 
 namespace GovServices.Server.Services;
 
 public class GeoService : IGeoService
 {
+    private readonly ApplicationDbContext _context;
+    private readonly IMapper _mapper;
+    private readonly GeometryFactory _geometryFactory;
+
+    public GeoService(ApplicationDbContext context, IMapper mapper)
+    {
+        _context = context;
+        _mapper = mapper;
+        _geometryFactory = NetTopologySuite.NtsGeometryServices.Instance.CreateGeometryFactory();
+    }
+
+    public async Task<List<GeoObjectDto>> GetAllAsync()
+    {
+        var objs = await _context.Set<GeoObject>().ToListAsync();
+        return _mapper.Map<List<GeoObjectDto>>(objs);
+    }
+
+    public async Task<GeoObjectDto?> GetByIdAsync(int id)
+    {
+        var obj = await _context.Set<GeoObject>().FirstOrDefaultAsync(g => g.Id == id);
+        return obj == null ? null : _mapper.Map<GeoObjectDto>(obj);
+    }
+
+    public async Task<GeoObjectDto> CreateAsync(CreateGeoObjectDto dto)
+    {
+        var reader = new WKTReader(_geometryFactory);
+        var geom = reader.Read(dto.WktGeometry);
+
+        var obj = new GeoObject
+        {
+            Name = dto.Name,
+            Geometry = geom,
+            Properties = dto.Properties
+        };
+
+        _context.Set<GeoObject>().Add(obj);
+        await _context.SaveChangesAsync();
+
+        return _mapper.Map<GeoObjectDto>(obj);
+    }
+
+    public async Task<List<GeoObjectDto>> GetIntersectingAsync(string wkt)
+    {
+        var reader = new WKTReader(_geometryFactory);
+        var queryGeom = reader.Read(wkt);
+
+        var objs = await _context.Set<GeoObject>()
+            .Where(g => EF.Functions.ST_Intersects(g.Geometry, queryGeom))
+            .ToListAsync();
+
+        return _mapper.Map<List<GeoObjectDto>>(objs);
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        var obj = await _context.Set<GeoObject>().FirstOrDefaultAsync(g => g.Id == id);
+        if (obj == null)
+            return;
+
+        _context.Set<GeoObject>().Remove(obj);
+        await _context.SaveChangesAsync();
+    }
 }


### PR DESCRIPTION
## Summary
- build out `IGeoService` interface
- implement `GeoService` class with geometry support
- register `GeoObjects` DbSet in `ApplicationDbContext`

## Testing
- `~/.dotnet/dotnet build Server.Api/Server.Api/Server.Api.csproj` *(fails: NETSDK1045)*

------
https://chatgpt.com/codex/tasks/task_e_684a948e48588323abae9ae514d1186a