### PR TITLE
Add OCR implementation

### DIFF
--- a/Server.Api/Server.Api/Services/OcrService.cs
+++ b/Server.Api/Server.Api/Services/OcrService.cs
@@ -4,8 +4,14 @@ namespace GovServices.Server.Services;
 
 public class OcrService : IOcrService
 {
-    public Task<string> RecognizeAsync(string filePath)
+    public async Task<string> RecognizeAsync(string filePath)
     {
-        return Task.FromResult(string.Empty);
+        return await Task.Run(() =>
+        {
+            using var engine = new Tesseract.TesseractEngine("./tessdata", "rus", Tesseract.EngineMode.Default);
+            using var img = Tesseract.Pix.LoadFromFile(filePath);
+            using var page = engine.Process(img);
+            return page.GetText();
+        });
     }
 }


### PR DESCRIPTION
## Summary
- implement the OCR service using Tesseract
- install local .NET SDKs 9.0 and 8.0 for build

## Testing
- `~/.dotnet/dotnet --list-sdks`
- `~/.dotnet/dotnet build GovServicesSolution.sln -v:minimal` *(fails: ApplicationDbContext missing)*

------
https://chatgpt.com/codex/tasks/task_e_684a9a6033988323a0dc76b1b2630c6d