### PR TITLE
Implement AuditService logging

### DIFF
--- a/Server.Api/Server.Api/Data/ApplicationDbContext.cs
+++ b/Server.Api/Server.Api/Data/ApplicationDbContext.cs
@@ -14,4 +14,5 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     public DbSet<Service> Services { get; set; } = default!;
     public DbSet<GeoObject> GeoObjects { get; set; } = default!;
     public DbSet<PasswordChangeLog> PasswordChangeLogs { get; set; } = default!;
+    public DbSet<AuditLog> AuditLogs { get; set; } = default!;
 }

--- a/Server.Api/Server.Api/Interfaces/IAuditService.cs
+++ b/Server.Api/Server.Api/Interfaces/IAuditService.cs
@@ -1,3 +1,8 @@
+using GovServices.Server.DTOs;
+
 namespace GovServices.Server.Interfaces;
 
-public interface IAuditService { }
+public interface IAuditService
+{
+    Task LogAsync(AuditLogDto dto);
+}

--- a/Server.Api/Server.Api/Services/AuditService.cs
+++ b/Server.Api/Server.Api/Services/AuditService.cs
@@ -1,7 +1,32 @@
+using GovServices.Server.Data;
+using GovServices.Server.DTOs;
+using GovServices.Server.Entities;
 using GovServices.Server.Interfaces;
 
 namespace GovServices.Server.Services;
 
 public class AuditService : IAuditService
 {
+    private readonly ApplicationDbContext _context;
+
+    public AuditService(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task LogAsync(AuditLogDto dto)
+    {
+        var ent = new AuditLog
+        {
+            UserName = dto.UserName,
+            ActionType = dto.ActionType,
+            EntityType = dto.EntityType,
+            EntityId = dto.EntityId,
+            Timestamp = dto.Timestamp,
+            DurationMs = dto.DurationMs
+        };
+
+        _context.AuditLogs.Add(ent);
+        await _context.SaveChangesAsync();
+    }
 }


### PR DESCRIPTION
## Summary
- add LogAsync method to `IAuditService`
- implement `AuditService` with EF Core persistence
- register `AuditLogs` DbSet in `ApplicationDbContext`

## Testing
- `~/.dotnet/dotnet build Server.Api/Server.Api/Server.Api.csproj -c Release` *(fails: ApplicationDbContext missing sets)*

------
https://chatgpt.com/codex/tasks/task_e_684a9f9da6048323aa7a93cc5f3c84ce