### PR TITLE
Implement password reminder background service

### DIFF
--- a/Server.Api/Server.Api/BackgroundServices/PasswordReminderService.cs
+++ b/Server.Api/Server.Api/BackgroundServices/PasswordReminderService.cs
@@ -1,12 +1,61 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using GovServices.Server.Data;
+using GovServices.Server.Entities;
+using GovServices.Server.Interfaces;
 
 namespace GovServices.Server.BackgroundServices;
 
 public class PasswordReminderService : BackgroundService
 {
-    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    private readonly IServiceProvider _services;
+
+    public PasswordReminderService(IServiceProvider services)
     {
-        // No-op background task
-        return Task.CompletedTask;
+        _services = services;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            using var scope = _services.CreateScope();
+            var ctx = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var email = scope.ServiceProvider.GetRequiredService<IEmailService>();
+
+            var cutoff = DateTime.UtcNow.AddDays(-30);
+            var weekAgo = DateTime.UtcNow.AddDays(-7);
+
+            var users = await ctx.Set<ApplicationUser>()
+                .Where(u => u.PasswordLastChangedAt <= cutoff)
+                .ToListAsync(stoppingToken);
+
+            foreach (var u in users)
+            {
+                var lastRem = await ctx.PasswordChangeLogs
+                    .Where(l => l.UserId == u.Id && l.Type == "ReminderSent")
+                    .OrderByDescending(l => l.Timestamp)
+                    .FirstOrDefaultAsync(stoppingToken);
+
+                if (lastRem == null || lastRem.Timestamp <= weekAgo)
+                {
+                    await email.SendPasswordReminderAsync(u);
+                    ctx.PasswordChangeLogs.Add(new PasswordChangeLog
+                    {
+                        UserId = u.Id,
+                        Type = "ReminderSent",
+                        Timestamp = DateTime.UtcNow
+                    });
+                }
+            }
+
+            await ctx.SaveChangesAsync(stoppingToken);
+            await Task.Delay(TimeSpan.FromHours(24), stoppingToken);
+        }
     }
 }

--- a/Server.Api/Server.Api/Program.cs
+++ b/Server.Api/Server.Api/Program.cs
@@ -79,6 +79,7 @@ builder.Services.AddScoped<AuditMiddleware>();
 
 // Background services
 builder.Services.AddHostedService<ExampleBackgroundService>();
+builder.Services.AddHostedService<PasswordReminderService>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- implement `PasswordReminderService`
- register the service in `Program.cs`

## Testing
- `dotnet build` *(fails: ApplicationDbContext missing definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684aa172e454832395767018027f9f9a