### PR TITLE
Add AutoMapper mappings for all DTOs

### DIFF
--- a/Server.Api/Server.Api/Mappings/MappingProfile.cs
+++ b/Server.Api/Server.Api/Mappings/MappingProfile.cs
@@ -18,6 +18,9 @@ namespace GovServices.Server.Mappings
                 .ForMember(d => d.AssignedToUserName, o => o.MapFrom(s => s.AssignedTo != null ? s.AssignedTo.FullName : null))
                 .ReverseMap();
 
+            CreateMap<CreateApplicationDto, Application>();
+            CreateMap<UpdateApplicationDto, Application>();
+
             CreateMap<ApplicationLog, ApplicationLogDto>()
                 .ForMember(d => d.UserName, o => o.MapFrom(s => s.User != null ? s.User.FullName : null))
                 .ReverseMap();
@@ -30,24 +33,38 @@ namespace GovServices.Server.Mappings
                 .ReverseMap()
                 .ForPath(s => s.Metadata.MetadataJson, o => o.MapFrom(d => d.MetadataJson));
 
+            CreateMap<CreateDocumentDto, Document>();
+
             CreateMap<GeoObject, GeoObjectDto>()
                 .ForMember(d => d.GeoJson, o => o.MapFrom(s => s.Geometry != null ? new GeoJsonWriter().Write(s.Geometry) : null))
                 .ReverseMap()
                 .ForMember(d => d.Geometry, o => o.MapFrom(s => !string.IsNullOrEmpty(s.GeoJson) ? new GeoJsonReader().Read<Geometry>(s.GeoJson) : null));
 
+            CreateMap<CreateGeoObjectDto, GeoObject>();
+
             CreateMap<Order, OrderDto>()
                 .ForMember(d => d.SignerUserName, o => o.MapFrom(s => s.Signer != null ? s.Signer.FullName : null))
                 .ReverseMap();
+
+            CreateMap<CreateOrderDto, Order>();
+            CreateMap<UpdateOrderDto, Order>();
 
             CreateMap<OutgoingDocument, OutgoingDocumentDto>()
                 .ForMember(d => d.AttachmentFileNames, o => o.MapFrom(s => s.Attachments != null ? s.Attachments.Select(a => a.FileName).ToList() : new List<string>()))
                 .ReverseMap()
                 .ForMember(d => d.Attachments, o => o.Ignore());
 
+            CreateMap<CreateOutgoingDocumentDto, OutgoingDocument>();
+
             CreateMap<RosreestrRequest, RosreestrRequestDto>().ReverseMap();
+            CreateMap<CreateRosreestrRequestDto, RosreestrRequest>();
             CreateMap<SedDocumentLog, SedDocumentLogDto>().ReverseMap();
             CreateMap<Service, ServiceDto>().ReverseMap();
+            CreateMap<CreateServiceDto, Service>();
+            CreateMap<UpdateServiceDto, Service>();
             CreateMap<Template, TemplateDto>().ReverseMap();
+            CreateMap<CreateTemplateDto, Template>();
+            CreateMap<UpdateTemplateDto, Template>();
             CreateMap<Workflow, WorkflowDto>().ReverseMap();
             CreateMap<WorkflowStep, WorkflowStepDto>().ReverseMap();
             CreateMap<WorkflowTransition, WorkflowTransitionDto>().ReverseMap();
@@ -56,6 +73,9 @@ namespace GovServices.Server.Mappings
                 .ForMember(d => d.DepartmentName, o => o.MapFrom(s => s.Department != null ? s.Department.Name : null))
                 .ForMember(d => d.Roles, o => o.Ignore())
                 .ReverseMap();
+
+            CreateMap<CreateUserDto, ApplicationUser>();
+            CreateMap<UpdateUserDto, ApplicationUser>();
         }
     }
 }


### PR DESCRIPTION
## Summary
- map Create/Update DTOs to corresponding entities
- ensure full AutoMapper coverage for all DTOs

## Testing
- `dotnet build GovServicesSolution.sln` *(fails: ApplicationDbContext missing definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684aa77fb27c8323ad4066a73a2b973c