### PR TITLE
Configure Client.Wasm Program.cs

### DIFF
--- a/Client.Wasm/Client.Wasm/Client.Wasm.csproj
+++ b/Client.Wasm/Client.Wasm/Client.Wasm.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Syncfusion.Blazor" Version="22.1.0.47" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.ProtectedBrowserStorage" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Client.Wasm/Client.Wasm/Helpers/JwtParser.cs
+++ b/Client.Wasm/Client.Wasm/Helpers/JwtParser.cs
@@ -1,0 +1,29 @@
+using System.Security.Claims;
+using System.Text.Json;
+
+namespace Client.Wasm.Helpers;
+
+public static class JwtParser
+{
+    public static IEnumerable<Claim> ParseClaimsFromJwt(string jwt)
+    {
+        var payload = jwt.Split('.')[1];
+        var jsonBytes = ParseBase64WithoutPadding(payload);
+        var keyValuePairs = JsonSerializer.Deserialize<Dictionary<string, object>>(jsonBytes);
+        if (keyValuePairs == null)
+        {
+            return Enumerable.Empty<Claim>();
+        }
+        return keyValuePairs.Select(kvp => new Claim(kvp.Key, kvp.Value.ToString() ?? string.Empty));
+    }
+
+    private static byte[] ParseBase64WithoutPadding(string base64)
+    {
+        switch (base64.Length % 4)
+        {
+            case 2: base64 += "=="; break;
+            case 3: base64 += "="; break;
+        }
+        return Convert.FromBase64String(base64);
+    }
+}

--- a/Client.Wasm/Client.Wasm/Program.cs
+++ b/Client.Wasm/Client.Wasm/Program.cs
@@ -1,11 +1,33 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using Syncfusion.Blazor;
 using Client.Wasm;
+using Client.Wasm.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+
+builder.Services.AddSyncfusionBlazor();
+builder.Services.AddScoped<ProtectedLocalStorage>();
+
+builder.Services.AddAuthorizationCore();
+builder.Services.AddScoped<CustomAuthStateProvider>();
+builder.Services.AddScoped<AuthenticationStateProvider>(sp => sp.GetRequiredService<CustomAuthStateProvider>());
+
+var assembly = typeof(Program).Assembly;
+var clients = assembly.GetTypes().Where(t => t.IsClass && !t.IsAbstract && t.Name.EndsWith("ApiClient"));
+foreach (var client in clients)
+{
+    var iface = client.GetInterface($"I{client.Name}");
+    if (iface != null)
+    {
+        builder.Services.AddScoped(iface, client);
+    }
+}
 
 await builder.Build().RunAsync();

--- a/Client.Wasm/Client.Wasm/Services/CustomAuthStateProvider.cs
+++ b/Client.Wasm/Client.Wasm/Services/CustomAuthStateProvider.cs
@@ -1,0 +1,48 @@
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using Client.Wasm.Helpers;
+
+namespace Client.Wasm.Services;
+
+public class CustomAuthStateProvider : AuthenticationStateProvider
+{
+    private readonly ProtectedLocalStorage _storage;
+    private readonly HttpClient _httpClient;
+    private readonly AuthenticationState _anonymous = new(new ClaimsPrincipal(new ClaimsIdentity()));
+
+    public CustomAuthStateProvider(ProtectedLocalStorage storage, HttpClient httpClient)
+    {
+        _storage = storage;
+        _httpClient = httpClient;
+    }
+
+    public override async Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        var result = await _storage.GetAsync<string>("authToken");
+        if (!result.Success || string.IsNullOrWhiteSpace(result.Value))
+        {
+            return _anonymous;
+        }
+
+        var token = result.Value!;
+        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var identity = new ClaimsIdentity(JwtParser.ParseClaimsFromJwt(token), "jwt");
+        var user = new ClaimsPrincipal(identity);
+        return new AuthenticationState(user);
+    }
+
+    public async Task SetTokenAsync(string token)
+    {
+        await _storage.SetAsync("authToken", token);
+        NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
+    }
+
+    public async Task RemoveTokenAsync()
+    {
+        await _storage.DeleteAsync("authToken");
+        _httpClient.DefaultRequestHeaders.Authorization = null;
+        NotifyAuthenticationStateChanged(Task.FromResult(_anonymous));
+    }
+}


### PR DESCRIPTION
## Summary
- add custom authentication state provider and JWT parser
- wire protected local storage, Syncfusion and DI for `*ApiClient`
- register `CustomAuthStateProvider` for AuthenticationState
- include ProtectedBrowserStorage package for WASM project

## Testing
- `dotnet restore GovServicesSolution.sln` *(fails: NETSDK1045 unsupported .NET 9)*
- `dotnet build --no-restore GovServicesSolution.sln` *(fails: assets missing and unsupported .NET 9)*


------
https://chatgpt.com/codex/tasks/task_e_684aae5b6e38832385edc7d319a01cfe