### PR TITLE
Fix PackageReference versions for .NET 8

### DIFF
--- a/Client.Wasm/Client.Wasm/Client.Wasm.csproj
+++ b/Client.Wasm/Client.Wasm/Client.Wasm.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.17" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Syncfusion.Blazor" Version="22.1.0.47" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.ProtectedBrowserStorage" Version="8.0.0" />
+    <PackageReference Include="Syncfusion.Blazor" Version="22.1.34" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.ProtectedBrowserStorage" Version="5.0.0-rc.1.20451.17" />
   </ItemGroup>
 
 </Project>

--- a/Client.Wasm/Client.Wasm/Program.cs
+++ b/Client.Wasm/Client.Wasm/Program.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.AspNetCore.Components.Authorization;
-using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using Microsoft.AspNetCore.Components.ProtectedBrowserStorage;
 using Syncfusion.Blazor;
 using Client.Wasm;
 using Client.Wasm.Services;

--- a/Client.Wasm/Client.Wasm/Services/CustomAuthStateProvider.cs
+++ b/Client.Wasm/Client.Wasm/Services/CustomAuthStateProvider.cs
@@ -1,7 +1,7 @@
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Components.Authorization;
-using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using Microsoft.AspNetCore.Components.ProtectedBrowserStorage;
 using Client.Wasm.Helpers;
 
 namespace Client.Wasm.Services;

--- a/Server.Api/Server.Api/Interfaces/IWorkflowService.cs
+++ b/Server.Api/Server.Api/Interfaces/IWorkflowService.cs
@@ -1,3 +1,14 @@
 namespace GovServices.Server.Interfaces;
 
-public interface IWorkflowService { }
+using GovServices.Server.DTOs;
+
+public interface IWorkflowService
+{
+    Task<List<WorkflowDto>> GetAllWorkflowsAsync(CancellationToken cancellationToken = default);
+    Task<WorkflowDto?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<WorkflowDto> CreateAsync(WorkflowDto dto, CancellationToken cancellationToken = default);
+    Task<bool> UpdateAsync(WorkflowDto dto, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default);
+    Task<bool> CanTransitionAsync(int fromStepId, int toStepId, object? contextData);
+    Task<WorkflowStepDto?> GetNextStepAsync(int currentStepId, object? contextData);
+}

--- a/Server.Api/Server.Api/Server.Api.csproj
+++ b/Server.Api/Server.Api/Server.Api.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DinkToPdf" Version="0.9.0" />
+    <PackageReference Include="DinkToPdf" Version="1.0.8" />
     <PackageReference Include="MailKit" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
@@ -15,12 +15,13 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="8.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-    <PackageReference Include="Tesseract" Version="5.0.0.1" />
+    <PackageReference Include="Tesseract" Version="5.2.0" />
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-    <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="2.4.0" />
+    <PackageReference Include="NetTopologySuite" Version="2.6.0" />
+    <PackageReference Include="NetTopologySuite.IO.GeoJSON" Version="4.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
     <PackageReference Include="RazorLight" Version="2.0.0" />
   </ItemGroup>

--- a/Server.Api/Server.Api/Services/GeoService.cs
+++ b/Server.Api/Server.Api/Services/GeoService.cs
@@ -6,6 +6,7 @@ using GovServices.Server.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
+using Npgsql.EntityFrameworkCore.PostgreSQL;
 
 namespace GovServices.Server.Services;
 
@@ -58,7 +59,7 @@ public class GeoService : IGeoService
         var queryGeom = reader.Read(wkt);
 
         var objs = await _context.Set<GeoObject>()
-            .Where(g => EF.Functions.ST_Intersects(g.Geometry, queryGeom))
+            .Where(g => g.Geometry.Intersects(queryGeom))
             .ToListAsync();
 
         return _mapper.Map<List<GeoObjectDto>>(objs);


### PR DESCRIPTION
## Summary
- fix versions of NuGet packages in Server.Api.csproj
- align Client.Wasm package references
- update workflow service interface
- add missing using and method update in GeoService
- restore/build with .NET 8

## Testing
- `dotnet restore GovServicesSolution.sln --verbosity minimal`
- `dotnet build GovServicesSolution.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_684ab380049483238d1a945080d2a54e