### PR TITLE
Add Dockerfile for Server.Api

### DIFF
--- a/Server.Api/.dockerignore
+++ b/Server.Api/.dockerignore
@@ -1,0 +1,3 @@
+bin/
+obj/
+AppSettings.json

--- a/Server.Api/Dockerfile
+++ b/Server.Api/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+WORKDIR /app
+EXPOSE 80
+
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY ["Server.Api/Server.Api.csproj", "Server.Api/"]
+RUN dotnet restore "Server.Api/Server.Api.csproj"
+COPY . .
+WORKDIR "/src/Server.Api"
+RUN dotnet build -c Release -o /app/build
+RUN dotnet publish -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "Server.Api.dll"]


### PR DESCRIPTION
## Summary
- add Dockerfile for building the Server.Api
- add dockerignore rules

## Testing
- `dotnet restore GovServicesSolution.sln`
- `dotnet build GovServicesSolution.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_684abc7087d08323abec23b8085da3c7