### PR TITLE
Add Client.Wasm Dockerfile

### DIFF
--- a/Client.Wasm/.dockerignore
+++ b/Client.Wasm/.dockerignore
@@ -1,0 +1,3 @@
+bin/
+obj/
+node_modules/

--- a/Client.Wasm/Dockerfile
+++ b/Client.Wasm/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["Client.Wasm/Client.Wasm.csproj", "Client.Wasm/"]
+RUN dotnet restore "Client.Wasm/Client.Wasm.csproj"
+COPY . .
+WORKDIR "/src/Client.Wasm"
+RUN dotnet publish -c Release -o /app/publish
+
+FROM nginx:alpine AS final
+WORKDIR /usr/share/nginx/html
+COPY --from=build /app/publish/wwwroot .
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- add Dockerfile for the Blazor client project
- ignore build artifacts in docker context

## Testing
- `dotnet build GovServicesSolution.sln -c Release` *(fails: CS1503 etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684ac1a47de08323b3837239c1ed114d