### PR TITLE
Fix Syncfusion Blazor pages for .NET 8

### DIFF
--- a/Client.Wasm/Client.Wasm/Pages/ApplicationDetails.razor
+++ b/Client.Wasm/Client.Wasm/Pages/ApplicationDetails.razor
@@ -26,7 +26,7 @@
                 <p><b>Обновлена:</b> @app.UpdatedAt.ToShortDateString()</p>
             </SfCardContent>
         </SfCard>
-        <SfButton CssClass="e-flat" IconCss="e-icons e-arrow-left" OnClick="@(()=>NavigationManager.NavigateTo("/applications"))">Назад</SfButton>
+        <SfButton CssClass="e-flat" IconCss="e-icons e-arrow-left" OnClick="@( (MouseEventArgs e) => NavigationManager.NavigateTo("/applications") )">Назад</SfButton>
     }
 </div>
 

--- a/Client.Wasm/Client.Wasm/Pages/ApplicationEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/ApplicationEdit.razor
@@ -13,7 +13,7 @@
         <SfTextBox TValue="string" Multiline="true" @bind-Value="formData" Placeholder="Данные формы (JSON)" CssClass="mb-3 w-100" Rows="4" />
         <div class="text-right">
             <SfButton Type="Submit" CssClass="e-primary me-2">Сохранить</SfButton>
-            <SfButton CssClass="e-flat" OnClick="()=>dlg.Hide()">Отмена</SfButton>
+            <SfButton CssClass="e-flat" OnClick="@( (MouseEventArgs e) => dlg.Hide() )">Отмена</SfButton>
         </div>
     </EditForm>
 </SfDialog>

--- a/Client.Wasm/Client.Wasm/Pages/Applications.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Applications.razor
@@ -9,8 +9,9 @@
 
 <div class="container p-4">
     <h1>Заявки</h1>
-    <SfButton CssClass="e-primary mb-3" IconCss="e-icons e-add" OnClick="OpenNew">Новая заявка</SfButton>
-    <SfGrid DataSource="@items" AllowPaging="true" PageSettings="@(new Syncfusion.Blazor.Grids.GridPageSettings { PageSize = 10 })" Toolbar="@toolbar" Width="100%">
+    <SfButton CssClass="e-primary mb-3" IconCss="e-icons e-add" OnClick="@( (MouseEventArgs e) => OpenNew() )">Новая заявка</SfButton>
+    <SfGrid TItem="ApplicationDto" DataSource="@items" AllowPaging="true" Toolbar="@toolbar" Width="100%">
+        <GridPageSettings PageSize="10" />
         <GridColumns>
             <GridColumn Field=@nameof(ApplicationDto.Id) HeaderText="ID" Width="70" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
             <GridColumn Field=@nameof(ApplicationDto.Number) HeaderText="Номер" Width="120" />
@@ -19,9 +20,9 @@
             <GridColumn Field=@nameof(ApplicationDto.UpdatedAt) HeaderText="Обновлено" Format="d" Width="120" />
             <GridColumn HeaderText="Действия" TextAlign="TextAlign.Center" Width="180">
                 <Template>
-                    <SfButton CssClass="e-flat" IconCss="e-icons e-open" OnClick="@(() => Details((context as ApplicationDto).Id))"></SfButton>
-                    <SfButton CssClass="e-flat" IconCss="e-icons e-edit" OnClick="@(() => Edit((context as ApplicationDto).Id))"></SfButton>
-                    <SfButton CssClass="e-flat e-danger" IconCss="e-icons e-delete" OnClick="@(() => Delete((context as ApplicationDto).Id))"></SfButton>
+                    <SfButton CssClass="e-flat" IconCss="e-icons e-open" OnClick="@( (MouseEventArgs e) => Details((context as ApplicationDto).Id) )"></SfButton>
+                    <SfButton CssClass="e-flat" IconCss="e-icons e-edit" OnClick="@( (MouseEventArgs e) => Edit((context as ApplicationDto).Id) )"></SfButton>
+                    <SfButton CssClass="e-flat e-danger" IconCss="e-icons e-delete" OnClick="@( (MouseEventArgs e) => Delete((context as ApplicationDto).Id) )"></SfButton>
                 </Template>
             </GridColumn>
         </GridColumns>

--- a/Client.Wasm/Client.Wasm/Pages/Documents.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Documents.razor
@@ -9,7 +9,8 @@
 
 <div class="container p-4">
     <h1>Документы</h1>
-    <SfGrid DataSource="@docs" AllowPaging="true" PageSettings="@(new Syncfusion.Blazor.Grids.GridPageSettings { PageSize = 10 })" Width="100%">
+    <SfGrid TItem="DocumentDto" DataSource="@docs" AllowPaging="true" Width="100%">
+        <GridPageSettings PageSize="10" />
         <GridColumns>
             <GridColumn Field=@nameof(DocumentDto.Id) HeaderText="ID" Width="70" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
             <GridColumn Field=@nameof(DocumentDto.FileName) HeaderText="Файл" Width="*" />

--- a/Client.Wasm/Client.Wasm/Pages/OrderEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/OrderEdit.razor
@@ -9,11 +9,11 @@
     <EditForm Model="model" OnValidSubmit="Save">
         <DataAnnotationsValidator />
         <SfTextBox TValue="string" @bind-Value="model.Number" Placeholder="Номер" CssClass="mb-3 w-100" />
-        <SfDatePicker TValue="DateTime?" @bind-Value="model.Date" Placeholder="Дата" CssClass="mb-3 w-100" />
+        <SfDatePicker TValue="DateTime" @bind-Value="model.Date" Placeholder="Дата" CssClass="mb-3 w-100" />
         <SfTextBox TValue="string" Multiline="true" @bind-Value="model.Text" Placeholder="Текст" CssClass="mb-3 w-100" Rows="3" />
         <div class="text-right">
             <SfButton Type="Submit" CssClass="e-primary me-2">Сохранить</SfButton>
-            <SfButton CssClass="e-flat" OnClick="()=>dlg.Hide()">Отмена</SfButton>
+            <SfButton CssClass="e-flat" OnClick="@( (MouseEventArgs e) => dlg.Hide() )">Отмена</SfButton>
         </div>
     </EditForm>
 </SfDialog>

--- a/Client.Wasm/Client.Wasm/Pages/Orders.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Orders.razor
@@ -8,15 +8,15 @@
 @inject NavigationManager NavigationManager
 <div class="container p-4">
     <h1>Приказы</h1>
-    <SfButton CssClass="e-primary mb-3" IconCss="e-icons e-add" OnClick="()=>edit.Show(new OrderDto())">Добавить приказ</SfButton>
-    <SfGrid DataSource="@orders" Width="100%">
+    <SfButton CssClass="e-primary mb-3" IconCss="e-icons e-add" OnClick="@( (MouseEventArgs e) => edit.Show(new OrderDto()) )">Добавить приказ</SfButton>
+    <SfGrid TItem="OrderDto" DataSource="@orders" Width="100%">
         <GridColumns>
             <GridColumn Field=@nameof(OrderDto.Id) HeaderText="ID" Width="70" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
             <GridColumn Field=@nameof(OrderDto.Number) HeaderText="Номер" Width="120" />
             <GridColumn Field=@nameof(OrderDto.Date) HeaderText="Дата" Format="d" Width="120" />
             <GridColumn HeaderText="Действия" TextAlign="TextAlign.Center" Width="120">
                 <Template>
-                    <SfButton CssClass="e-flat" IconCss="e-icons e-edit" OnClick="@(() => edit.Load((context as OrderDto).Id))" />
+                    <SfButton CssClass="e-flat" IconCss="e-icons e-edit" OnClick="@( (MouseEventArgs e) => edit.Load((context as OrderDto).Id) )" />
                 </Template>
             </GridColumn>
         </GridColumns>

--- a/Client.Wasm/Client.Wasm/Pages/Outgoing.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Outgoing.razor
@@ -9,7 +9,8 @@
 
 <div class="container p-4">
     <h1>Исходящие документы</h1>
-    <SfGrid DataSource="@items" AllowPaging="true" PageSettings="@(new Syncfusion.Blazor.Grids.GridPageSettings { PageSize = 10 })" Width="100%">
+    <SfGrid TItem="OutgoingDocumentDto" DataSource="@items" AllowPaging="true" Width="100%">
+        <GridPageSettings PageSize="10" />
         <GridColumns>
             <GridColumn Field=@nameof(OutgoingDocumentDto.Id) HeaderText="ID" Width="70" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
             <GridColumn Field=@nameof(OutgoingDocumentDto.FileName) HeaderText="Файл" Width="*" />

--- a/Client.Wasm/Client.Wasm/Pages/ServiceEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/ServiceEdit.razor
@@ -13,7 +13,7 @@
         <SfTextBox TValue="string" Multiline="true" @bind-Value="model.Description" Placeholder="Описание" CssClass="mb-3 w-100" Rows="3" />
         <div class="text-right">
             <SfButton CssClass="e-primary me-2" Type="Submit">Сохранить</SfButton>
-            <SfButton CssClass="e-flat" OnClick="() => dialog.Hide()">Отмена</SfButton>
+            <SfButton CssClass="e-flat" OnClick="@( (MouseEventArgs e) => dialog.Hide() )">Отмена</SfButton>
         </div>
     </EditForm>
 </SfDialog>

--- a/Client.Wasm/Client.Wasm/Pages/Services.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Services.razor
@@ -9,8 +9,9 @@
 
 <div class="container p-4">
     <h1>Услуги</h1>
-    <SfButton CssClass="e-primary mb-3" IconCss="e-icons e-add" OnClick="OpenNew">Добавить услугу</SfButton>
-    <SfGrid DataSource="@services" AllowPaging="true" PageSettings="@(new Syncfusion.Blazor.Grids.GridPageSettings { PageSize = 10 })" Toolbar="@toolbarOptions" Width="100%">
+    <SfButton CssClass="e-primary mb-3" IconCss="e-icons e-add" OnClick="@( (MouseEventArgs e) => OpenNew() )">Добавить услугу</SfButton>
+    <SfGrid TItem="ServiceDto" DataSource="@services" AllowPaging="true" Toolbar="@toolbarOptions" Width="100%">
+        <GridPageSettings PageSize="10" />
         <GridColumns>
             <GridColumn Field=@nameof(ServiceDto.Id) HeaderText="ID" Width="70" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
             <GridColumn Field=@nameof(ServiceDto.Name) HeaderText="Название" Width="200" />
@@ -19,8 +20,8 @@
             <GridColumn Field=@nameof(ServiceDto.UpdatedAt) HeaderText="Обновлена" Format="d" TextAlign="TextAlign.Center" Width="120" />
             <GridColumn HeaderText="Действия" Width="150" TextAlign="TextAlign.Center">
                 <Template>
-                    <SfButton CssClass="e-flat" IconCss="e-icons e-edit" OnClick="@(() => Edit((context as ServiceDto).Id))"></SfButton>
-                    <SfButton CssClass="e-flat e-danger" IconCss="e-icons e-delete" OnClick="@(() => Delete((context as ServiceDto).Id))"></SfButton>
+                    <SfButton CssClass="e-flat" IconCss="e-icons e-edit" OnClick="@( (MouseEventArgs e) => Edit((context as ServiceDto).Id) )"></SfButton>
+                    <SfButton CssClass="e-flat e-danger" IconCss="e-icons e-delete" OnClick="@( (MouseEventArgs e) => Delete((context as ServiceDto).Id) )"></SfButton>
                 </Template>
             </GridColumn>
         </GridColumns>

--- a/Client.Wasm/Client.Wasm/Pages/TemplateEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/TemplateEdit.razor
@@ -9,29 +9,26 @@
 <SfDialog @ref="dlg" Width="450px" ShowCloseIcon="true" Header="@hdr">
     <EditForm Model="model" OnValidSubmit="Save">
         <DataAnnotationsValidator />
-        <SfTextBox TValue="string" @bind-Value="@(((dynamic)model).Name)" Placeholder="Название" CssClass="mb-3 w-100" />
-        <SfTextBox TValue="string" @bind-Value="@(((dynamic)model).Type)" Placeholder="Тип" CssClass="mb-3 w-100" />
-        <SfTextBox TValue="string" Multiline="true" @bind-Value="@(((dynamic)model).Content)" Placeholder="Содержимое" CssClass="mb-3 w-100" Rows="6" />
+        <SfTextBox TValue="string" @bind-Value="model.Name" Placeholder="Название" CssClass="mb-3 w-100" />
+        <SfTextBox TValue="string" @bind-Value="model.Type" Placeholder="Тип" CssClass="mb-3 w-100" />
+        <InputTextArea @bind-Value="model.Content" class="form-control mb-3" rows="6" placeholder="Содержимое" />
         <div class="text-right">
             <SfButton Type="Submit" CssClass="e-primary me-2">Сохранить</SfButton>
-            <SfButton CssClass="e-flat" OnClick="()=>dlg.Hide()">Отмена</SfButton>
+            <SfButton CssClass="e-flat" OnClick="@( (MouseEventArgs e) => dlg.Hide() )">Отмена</SfButton>
         </div>
     </EditForm>
 </SfDialog>
 
 @code {
     SfDialog dlg;
-    dynamic model;
-    CreateTemplateDto createModel = new();
-    UpdateTemplateDto updateModel = new();
+    TemplateDto model = new();
     bool isNew;
     int editId;
     string hdr;
 
     public void Show(CreateTemplateDto dto)
     {
-        createModel = new CreateTemplateDto();
-        model = createModel;
+        model = new TemplateDto();
         hdr = "Новый шаблон";
         isNew = true;
         dlg.Show();
@@ -40,8 +37,7 @@
     public async void Load(int id)
     {
         var t = await ApiClient.GetByIdAsync(id);
-        updateModel = new UpdateTemplateDto { Name = t.Name, Type = t.Type, Content = t.Content };
-        model = updateModel;
+        model = new TemplateDto { Id = t.Id, Name = t.Name, Type = t.Type, Content = t.Content };
         editId = id;
         hdr = $"Редактировать шаблон #{id}";
         isNew = false;
@@ -51,9 +47,9 @@
     async Task Save()
     {
         if (isNew)
-            await ApiClient.CreateAsync(createModel);
+            await ApiClient.CreateAsync(new CreateTemplateDto { Name = model.Name, Type = model.Type, Content = model.Content });
         else
-            await ApiClient.UpdateAsync(editId, updateModel);
+            await ApiClient.UpdateAsync(editId, new UpdateTemplateDto { Name = model.Name, Type = model.Type, Content = model.Content });
         dlg.Hide();
         if (OnSaved.HasDelegate)
         {

--- a/Client.Wasm/Client.Wasm/Pages/TemplateGenerate.razor
+++ b/Client.Wasm/Client.Wasm/Pages/TemplateGenerate.razor
@@ -8,10 +8,10 @@
         <SfTextBox TValue="string" @bind-Value="model.ApplicantName" Placeholder="Заявитель" CssClass="mb-3 w-100" />
         <SfTextBox TValue="string" @bind-Value="model.ServiceName" Placeholder="Услуга" CssClass="mb-3 w-100" />
         <SfTextBox TValue="string" @bind-Value="model.StepName" Placeholder="Шаг" CssClass="mb-3 w-100" />
-        <SfDatePicker TValue="DateTime?" @bind-Value="model.Date" Placeholder="Дата" CssClass="mb-3 w-100" />
+        <SfDatePicker TValue="DateTime" @bind-Value="model.Date" Placeholder="Дата" CssClass="mb-3 w-100" />
         <div class="text-right">
             <SfButton Type="Submit" CssClass="e-primary me-2">Сгенерировать</SfButton>
-            <SfButton CssClass="e-flat" OnClick="()=>dlg.Hide()">Отмена</SfButton>
+            <SfButton CssClass="e-flat" OnClick="@( (MouseEventArgs e) => dlg.Hide() )">Отмена</SfButton>
         </div>
     </EditForm>
 </SfDialog>

--- a/Client.Wasm/Client.Wasm/Pages/Templates.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Templates.razor
@@ -9,17 +9,17 @@
 
 <div class="container p-4">
     <h1>Шаблоны</h1>
-    <SfButton CssClass="e-primary mb-3" IconCss="e-icons e-add" OnClick="()=>edit.Show(new CreateTemplateDto())">Новый шаблон</SfButton>
-    <SfGrid DataSource="@items" AllowPaging="true" Width="100%">
+    <SfButton CssClass="e-primary mb-3" IconCss="e-icons e-add" OnClick="@( (MouseEventArgs e) => edit.Show(new CreateTemplateDto()) )">Новый шаблон</SfButton>
+    <SfGrid TItem="TemplateDto" DataSource="@items" AllowPaging="true" Width="100%">
         <GridColumns>
             <GridColumn Field=@nameof(TemplateDto.Id) HeaderText="ID" Width="70" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
             <GridColumn Field=@nameof(TemplateDto.Name) HeaderText="Название" Width="200" />
             <GridColumn Field=@nameof(TemplateDto.Type) HeaderText="Тип" Width="120" />
             <GridColumn HeaderText="Действия" TextAlign="TextAlign.Center" Width="200">
                 <Template>
-                    <SfButton CssClass="e-flat" IconCss="e-icons e-edit" OnClick="@(() => edit.Load((context as TemplateDto).Id))" />
-                    <SfButton CssClass="e-flat" IconCss="e-icons e-download" OnClick="@(() => generator.Show((context as TemplateDto).Id))" />
-                    <SfButton CssClass="e-flat e-danger" IconCss="e-icons e-delete" OnClick="@(() => Delete((context as TemplateDto).Id))" />
+                    <SfButton CssClass="e-flat" IconCss="e-icons e-edit" OnClick="@( (MouseEventArgs e) => edit.Load((context as TemplateDto).Id) )" />
+                    <SfButton CssClass="e-flat" IconCss="e-icons e-download" OnClick="@( (MouseEventArgs e) => generator.Show((context as TemplateDto).Id) )" />
+                    <SfButton CssClass="e-flat e-danger" IconCss="e-icons e-delete" OnClick="@( (MouseEventArgs e) => Delete((context as TemplateDto).Id) )" />
                 </Template>
             </GridColumn>
         </GridColumns>

--- a/Client.Wasm/Client.Wasm/Pages/UserEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/UserEdit.razor
@@ -9,31 +9,28 @@
 <SfDialog @ref="dlg" Width="450px" ShowCloseIcon="true" Header="@hdr">
     <EditForm Model="model" OnValidSubmit="Save">
         <DataAnnotationsValidator />
-        <SfTextBox TValue="string" @bind-Value="@(((dynamic)model).Email)" Placeholder="Email" CssClass="mb-3 w-100" />
-        <SfTextBox TValue="string" @bind-Value="@(((dynamic)model).FullName)" Placeholder="ФИО" CssClass="mb-3 w-100" />
-        <SfNumericTextBox TValue="int" @bind-Value="@(((dynamic)model).DepartmentId)" Placeholder="ID отдела" CssClass="mb-3 w-100" />
+        <SfTextBox TValue="string" @bind-Value="model.Email" Placeholder="Email" CssClass="mb-3 w-100" />
+        <SfTextBox TValue="string" @bind-Value="model.FullName" Placeholder="ФИО" CssClass="mb-3 w-100" />
+        <SfNumericTextBox TValue="int" @bind-Value="model.DepartmentId" Placeholder="ID отдела" CssClass="mb-3 w-100" />
         <SfTextBox TValue="string" @bind-Value="roles" Placeholder="Роли (через запятую)" CssClass="mb-3 w-100" />
         <div class="text-right">
             <SfButton Type="Submit" CssClass="e-primary me-2">Сохранить</SfButton>
-            <SfButton CssClass="e-flat" OnClick="()=>dlg.Hide()">Отмена</SfButton>
+            <SfButton CssClass="e-flat" OnClick="@( (MouseEventArgs e) => dlg.Hide() )">Отмена</SfButton>
         </div>
     </EditForm>
 </SfDialog>
 
 @code {
     SfDialog dlg;
-    dynamic model;
-    CreateUserDto createModel = new();
-    UpdateUserDto updateModel = new();
+    CreateUserDto model = new();
     bool isNew;
     string hdr;
-    string id;
+    string id = string.Empty;
     string roles = string.Empty;
 
     public void Show(CreateUserDto dto)
     {
-        createModel = new CreateUserDto { RoleIds = new List<string>() };
-        model = createModel;
+        model = new CreateUserDto { RoleIds = new List<string>() };
         hdr = "Новый пользователь";
         isNew = true;
         dlg.Show();
@@ -44,8 +41,7 @@
         var u = await ApiClient.GetByIdAsync(userId);
         id = userId;
         roles = string.Join(',', u.Roles);
-        updateModel = new UpdateUserDto { FullName = u.FullName, DepartmentId = 0, RoleIds = u.Roles };
-        model = updateModel;
+        model = new CreateUserDto { Email = u.Email, FullName = u.FullName, DepartmentId = 0, RoleIds = u.Roles };
         hdr = "Редактировать пользователя";
         isNew = false;
         dlg.Show();
@@ -56,13 +52,12 @@
         var list = roles.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(r => r.Trim()).ToList();
         if (isNew)
         {
-            createModel.RoleIds = list;
-            await ApiClient.CreateAsync(createModel);
+            model.RoleIds = list;
+            await ApiClient.CreateAsync(model);
         }
         else
         {
-            updateModel.RoleIds = list;
-            await ApiClient.UpdateAsync(id, updateModel);
+            await ApiClient.UpdateAsync(id, new UpdateUserDto { FullName = model.FullName, DepartmentId = model.DepartmentId, RoleIds = list });
         }
         dlg.Hide();
         if (OnSaved.HasDelegate)

--- a/Client.Wasm/Client.Wasm/Pages/Users.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Users.razor
@@ -9,8 +9,8 @@
 
 <div class="container p-4">
     <h1>Пользователи</h1>
-    <SfButton CssClass="e-primary mb-3" IconCss="e-icons e-add" OnClick="()=>edit.Show(new CreateUserDto())">Добавить пользователя</SfButton>
-    <SfGrid DataSource="@items" AllowPaging="true" Width="100%">
+    <SfButton CssClass="e-primary mb-3" IconCss="e-icons e-add" OnClick="@( (MouseEventArgs e) => edit.Show(new CreateUserDto()) )">Добавить пользователя</SfButton>
+    <SfGrid TItem="UserDto" DataSource="@items" AllowPaging="true" Width="100%">
         <GridColumns>
             <GridColumn Field=@nameof(UserDto.Id) HeaderText="ID" Width="120" />
             <GridColumn Field=@nameof(UserDto.Email) HeaderText="Email" Width="200" />
@@ -22,8 +22,8 @@
             </GridColumn>
             <GridColumn HeaderText="Действия" TextAlign="TextAlign.Center" Width="150">
                 <Template>
-                    <SfButton CssClass="e-flat" IconCss="e-icons e-edit" OnClick="@(() => edit.Load((context as UserDto).Id))" />
-                    <SfButton CssClass="e-flat e-danger" IconCss="e-icons e-delete" OnClick="@(() => Delete((context as UserDto).Id))" />
+                    <SfButton CssClass="e-flat" IconCss="e-icons e-edit" OnClick="@( (MouseEventArgs e) => edit.Load((context as UserDto).Id) )" />
+                    <SfButton CssClass="e-flat e-danger" IconCss="e-icons e-delete" OnClick="@( (MouseEventArgs e) => Delete((context as UserDto).Id) )" />
                 </Template>
             </GridColumn>
         </GridColumns>

--- a/Client.Wasm/Client.Wasm/Pages/WorkflowEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/WorkflowEdit.razor
@@ -13,7 +13,7 @@
         <SfTextBox TValue="string" Multiline="true" @bind-Value="model.Description" Placeholder="Описание" CssClass="mb-3 w-100" Rows="4" />
         <div class="text-right">
             <SfButton Type="Submit" CssClass="e-primary me-2">Сохранить</SfButton>
-            <SfButton CssClass="e-flat" OnClick="()=>dlg.Hide()">Отмена</SfButton>
+            <SfButton CssClass="e-flat" OnClick="@( (MouseEventArgs e) => dlg.Hide() )">Отмена</SfButton>
         </div>
     </EditForm>
 </SfDialog>

--- a/Client.Wasm/Client.Wasm/Pages/Workflows.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Workflows.razor
@@ -9,16 +9,17 @@
 
 <div class="container p-4">
     <h1>Маршруты</h1>
-    <SfButton CssClass="e-primary mb-3" IconCss="e-icons e-add" OnClick="()=>edit.Show()">Новый маршрут</SfButton>
-    <SfGrid DataSource="@items" AllowPaging="true" PageSettings="@(new Syncfusion.Blazor.Grids.GridPageSettings { PageSize = 10 })" Width="100%">
+    <SfButton CssClass="e-primary mb-3" IconCss="e-icons e-add" OnClick="@( (MouseEventArgs e) => edit.Show() )">Новый маршрут</SfButton>
+    <SfGrid TItem="WorkflowDto" DataSource="@items" AllowPaging="true" Width="100%">
+        <GridPageSettings PageSize="10" />
         <GridColumns>
             <GridColumn Field=@nameof(WorkflowDto.Id) HeaderText="ID" Width="70" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
             <GridColumn Field=@nameof(WorkflowDto.Name) HeaderText="Название" Width="*"/>
             <GridColumn Field=@nameof(WorkflowDto.Description) HeaderText="Описание" Width="2*"/>
             <GridColumn HeaderText="Действия" TextAlign="TextAlign.Center" Width="150">
                 <Template>
-                    <SfButton CssClass="e-flat" IconCss="e-icons e-edit" OnClick="@(() => edit.Load((context as WorkflowDto).Id))" />
-                    <SfButton CssClass="e-flat e-danger" IconCss="e-icons e-delete" OnClick="@(() => Delete((context as WorkflowDto).Id))" />
+                    <SfButton CssClass="e-flat" IconCss="e-icons e-edit" OnClick="@( (MouseEventArgs e) => edit.Load((context as WorkflowDto).Id) )" />
+                    <SfButton CssClass="e-flat e-danger" IconCss="e-icons e-delete" OnClick="@( (MouseEventArgs e) => Delete((context as WorkflowDto).Id) )" />
                 </Template>
             </GridColumn>
         </GridColumns>

--- a/Client.Wasm/Client.Wasm/_Imports.razor
+++ b/Client.Wasm/Client.Wasm/_Imports.razor
@@ -18,9 +18,6 @@
 @using Syncfusion.Blazor.Navigations
 @using Syncfusion.Blazor.Popups
 @using Syncfusion.Blazor.Layouts
-@using Syncfusion.Blazor
-@using Syncfusion.Blazor.Grids
-@using Syncfusion.Blazor.Inputs
-@using Syncfusion.Blazor.Navigations
 @using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
 @using Microsoft.JSInterop


### PR DESCRIPTION
## Summary
- update imports for Syncfusion and Blazor
- update grids to use child `<GridPageSettings>` and specify `TItem`
- use typed event handlers
- replace template content editor with `<InputTextArea>`
- refactor user and template edit pages to avoid `dynamic`

## Testing
- `dotnet clean GovServicesSolution.sln`
- `dotnet build GovServicesSolution.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_684acc81f6888323b02d62fa1d31d2cc