### PR TITLE
Switch to Blazored.LocalStorage and fix AuditMiddleware usage

### DIFF
--- a/Client.Wasm/Client.Wasm/Client.Wasm.csproj
+++ b/Client.Wasm/Client.Wasm/Client.Wasm.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Blazored.LocalStorage" Version="4.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.17" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Syncfusion.Blazor" Version="22.1.34" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.ProtectedBrowserStorage" Version="5.0.0-rc.1.20451.17" />
   </ItemGroup>
 
 </Project>

--- a/Client.Wasm/Client.Wasm/Program.cs
+++ b/Client.Wasm/Client.Wasm/Program.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.AspNetCore.Components.Authorization;
-using Microsoft.AspNetCore.Components.ProtectedBrowserStorage;
+using Blazored.LocalStorage;
 using Syncfusion.Blazor;
 using Client.Wasm;
 using Client.Wasm.Services;
@@ -13,7 +13,7 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
 builder.Services.AddSyncfusionBlazor();
-builder.Services.AddScoped<ProtectedLocalStorage>();
+builder.Services.AddBlazoredLocalStorage();
 
 builder.Services.AddAuthorizationCore();
 builder.Services.AddScoped<CustomAuthStateProvider>();

--- a/Client.Wasm/Client.Wasm/Services/CustomAuthStateProvider.cs
+++ b/Client.Wasm/Client.Wasm/Services/CustomAuthStateProvider.cs
@@ -1,18 +1,18 @@
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Components.Authorization;
-using Microsoft.AspNetCore.Components.ProtectedBrowserStorage;
+using Blazored.LocalStorage;
 using Client.Wasm.Helpers;
 
 namespace Client.Wasm.Services;
 
 public class CustomAuthStateProvider : AuthenticationStateProvider
 {
-    private readonly ProtectedLocalStorage _storage;
+    private readonly ILocalStorageService _storage;
     private readonly HttpClient _httpClient;
     private readonly AuthenticationState _anonymous = new(new ClaimsPrincipal(new ClaimsIdentity()));
 
-    public CustomAuthStateProvider(ProtectedLocalStorage storage, HttpClient httpClient)
+    public CustomAuthStateProvider(ILocalStorageService storage, HttpClient httpClient)
     {
         _storage = storage;
         _httpClient = httpClient;
@@ -20,13 +20,11 @@ public class CustomAuthStateProvider : AuthenticationStateProvider
 
     public override async Task<AuthenticationState> GetAuthenticationStateAsync()
     {
-        var result = await _storage.GetAsync<string>("authToken");
-        if (!result.Success || string.IsNullOrWhiteSpace(result.Value))
+        var token = await _storage.GetItemAsync<string>("authToken");
+        if (string.IsNullOrWhiteSpace(token))
         {
             return _anonymous;
         }
-
-        var token = result.Value!;
         _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         var identity = new ClaimsIdentity(JwtParser.ParseClaimsFromJwt(token), "jwt");
         var user = new ClaimsPrincipal(identity);
@@ -35,14 +33,14 @@ public class CustomAuthStateProvider : AuthenticationStateProvider
 
     public async Task SetTokenAsync(string token)
     {
-        await _storage.SetAsync("authToken", token);
+        await _storage.SetItemAsync("authToken", token);
         _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         NotifyAuthenticationStateChanged(GetAuthenticationStateAsync());
     }
 
     public async Task RemoveTokenAsync()
     {
-        await _storage.DeleteAsync("authToken");
+        await _storage.RemoveItemAsync("authToken");
         _httpClient.DefaultRequestHeaders.Authorization = null;
         NotifyAuthenticationStateChanged(Task.FromResult(_anonymous));
     }

--- a/Server.Api/Server.Api/Program.cs
+++ b/Server.Api/Server.Api/Program.cs
@@ -74,8 +74,6 @@ builder.Services.AddSwaggerGen(c =>
 // DI for services
 builder.Services.AddScoped<IExampleService, ExampleService>();
 
-// Middleware Audit
-builder.Services.AddScoped<AuditMiddleware>();
 
 // Background services
 builder.Services.AddHostedService<ExampleBackgroundService>();
@@ -94,6 +92,8 @@ if (app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 
 app.UseCors("AllowAll");
+
+app.UseRouting();
 
 app.UseAuthentication();
 app.UseAuthorization();


### PR DESCRIPTION
## Summary
- use Blazored.LocalStorage in WASM app
- remove ProtectedBrowserStorage references
- adjust CustomAuthStateProvider to use ILocalStorageService
- remove AuditMiddleware service registration and place middleware after routing

## Testing
- `dotnet restore`
- `dotnet build -c Release`


------
https://chatgpt.com/codex/tasks/task_e_685063f1d5108323a4d546598ac91109