### PR TITLE
Add default admin seeder

### DIFF
--- a/Server.Api/Server.Api/Data/DataSeeder.cs
+++ b/Server.Api/Server.Api/Data/DataSeeder.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Identity;
+using GovServices.Server.Entities;
+
+namespace GovServices.Server.Data
+{
+    public static class DataSeeder
+    {
+        public static async Task SeedAsync(IServiceProvider services)
+        {
+            var userManager = services.GetRequiredService<UserManager<ApplicationUser>>();
+            var roleManager = services.GetRequiredService<RoleManager<IdentityRole>>();
+
+            const string adminRole = "Administrator";
+            const string adminEmail = "admin@gosuslugi.local";
+            const string adminPassword = "P@ssw0rd123";
+
+            if (!await roleManager.RoleExistsAsync(adminRole))
+            {
+                await roleManager.CreateAsync(new IdentityRole(adminRole));
+            }
+
+            var admin = await userManager.FindByEmailAsync(adminEmail);
+            if (admin == null)
+            {
+                admin = new ApplicationUser
+                {
+                    UserName = adminEmail,
+                    Email = adminEmail,
+                    FullName = "Системный Администратор",
+                    EmailConfirmed = true,
+                    PasswordLastChangedAt = DateTime.UtcNow
+                };
+                var result = await userManager.CreateAsync(admin, adminPassword);
+                if (result.Succeeded)
+                {
+                    await userManager.AddToRoleAsync(admin, adminRole);
+                }
+            }
+        }
+    }
+}

--- a/Server.Api/Server.Api/Program.cs
+++ b/Server.Api/Server.Api/Program.cs
@@ -130,6 +130,11 @@ builder.Services.AddHostedService<StatusNotificationService>();
 
 var app = builder.Build();
 
+using (var scope = app.Services.CreateScope())
+{
+    await DataSeeder.SeedAsync(scope.ServiceProvider);
+}
+
 app.UseSerilogRequestLogging();
 
 if (app.Environment.IsDevelopment())


### PR DESCRIPTION
## Summary
- seed a default admin account when Server.Api starts

## Testing
- `dotnet build GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_68507b05aabc8323b9fe5cbb89883ac9