### PR TITLE
Fix login layout and authentication menu handling

### DIFF
--- a/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
+++ b/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
@@ -1,35 +1,41 @@
 @inherits LayoutComponentBase
 @inject IAuthService AuthService
 @inject NavigationManager NavigationManager
+@inject AuthenticationStateProvider AuthenticationStateProvider
 
-<SfToolbar CssClass="e-bootstrap5">
-    <ToolbarItems>
-        <ToolbarItem PrefixIcon="" Text="">
-            <Template>
-                <a class="navbar-brand" href="/">
-                    <img src="logo.png" alt="Logo" style="height:40px" class="me-2" />
-                </a>
-            </Template>
-        </ToolbarItem>
-        <ToolbarItem Text="Menu">
-            <Template>
-                <SfMenu Items="MenuItems" CssClass="e-bootstrap5"></SfMenu>
-            </Template>
-        </ToolbarItem>
-        <ToolbarItem Align="ItemAlign.Right">
-            <Template>
-                <AuthorizeView>
-                    <Authorized>
-                        <SfButton CssClass="e-primary" OnClick="Logout">Logout</SfButton>
-                    </Authorized>
-                    <NotAuthorized>
-                        <SfButton CssClass="e-primary" @onclick='() => NavigationManager.NavigateTo("login")'>Login</SfButton>
-                    </NotAuthorized>
-                </AuthorizeView>
-            </Template>
-        </ToolbarItem>
-    </ToolbarItems>
-</SfToolbar>
+<CascadingAuthenticationState>
+    <SfToolbar CssClass="e-bootstrap5">
+        <ToolbarItems>
+            <ToolbarItem PrefixIcon="" Text="">
+                <Template>
+                    <a class="navbar-brand" href="/">
+                        <img src="images/logo.png" alt="Logo" style="height:40px" class="me-2" />
+                    </a>
+                </Template>
+            </ToolbarItem>
+            @if (authState?.User?.Identity?.IsAuthenticated == true)
+            {
+                <ToolbarItem Text="Menu">
+                    <Template>
+                        <SfMenu Items="MenuItems" CssClass="e-bootstrap5"></SfMenu>
+                    </Template>
+                </ToolbarItem>
+            }
+            <ToolbarItem Align="ItemAlign.Right">
+                <Template>
+                    @if (authState?.User?.Identity?.IsAuthenticated == true)
+                    {
+                        <SfButton CssClass="e-danger" OnClick="Logout">Выйти</SfButton>
+                    }
+                    else
+                    {
+                        <SfButton CssClass="e-primary" OnClick="@(() => NavigationManager.NavigateTo("/login"))">Войти</SfButton>
+                    }
+                </Template>
+            </ToolbarItem>
+        </ToolbarItems>
+    </SfToolbar>
+</CascadingAuthenticationState>
 
 <div class="content p-4">
     @Body
@@ -40,6 +46,12 @@
 </footer>
 
 @code {
+    private AuthenticationState? authState;
+
+    protected override async Task OnInitializedAsync()
+    {
+        authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+    }
     List<MenuItem> MenuItems = new()
     {
         new MenuItem { Text = "Services", Url = "/services" },

--- a/Client.Wasm/Client.Wasm/Pages/Login.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Login.razor
@@ -4,7 +4,7 @@
 
 <div class="login-page">
   <SfCard CssClass="login-card">
-    <img src="favicon.png" alt="Логотип" class="login-logo" />
+    <img src="images/logo.png" alt="Логотип" class="login-logo" />
     <div class="login-title">ГУ ДИЗО</div>
     <EditForm Model="@model" OnValidSubmit="HandleLogin">
       <DataAnnotationsValidator />

--- a/Client.Wasm/Client.Wasm/_Imports.razor
+++ b/Client.Wasm/Client.Wasm/_Imports.razor
@@ -6,6 +6,7 @@
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.AspNetCore.Components.WebAssembly.Http
 @using Microsoft.JSInterop
+@using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Authorization
 @using Client.Wasm
 @using Client.Wasm.Layout

--- a/Client.Wasm/Client.Wasm/wwwroot/css/site.css
+++ b/Client.Wasm/Client.Wasm/wwwroot/css/site.css
@@ -1,22 +1,22 @@
 .login-page {
-  background: linear-gradient(135deg, #0d4e8c 0%, #2196f3 100%);
-  height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: "Segoe UI", sans-serif;
+    background: linear-gradient(135deg, #0d47a1 0%, #2196f3 100%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
 }
-.login-card {
-  width: 360px;
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-  padding: 2rem;
-  background-color: #ffffff;
-}
+
 .login-logo {
-  display: block;
-  margin: 0 auto 1rem;
-  height: 48px;
+    height: 48px;
+    margin: 0 auto 1rem;
+}
+
+.login-card {
+    width: 360px;
+    border-radius: 8px;
+    padding: 2rem;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    background-color: #fff;
 }
 .login-title {
   text-align: center;


### PR DESCRIPTION
## Summary
- update imports for authentication
- only show navigation menu after authentication
- add conditional Login/Logout button
- fix login logo path and styling
- update site.css styles
- remove logo image

## Testing
- `dotnet build Client.Wasm/Client.Wasm/Client.Wasm.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68514f1794848323a2bfddb51bdf9944