### PR TITLE
Enable JWT auth via symmetric key

### DIFF
--- a/Server.Api/Server.Api/appsettings.json
+++ b/Server.Api/Server.Api/appsettings.json
@@ -15,5 +15,8 @@
   },
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5432;Database=gov_services;Username=postgres;Password=postgres"
+  },
+  "JwtSettings": {
+    "SecretKey": "MySecretKey123456"
   }
 }


### PR DESCRIPTION
## Summary
- install .NET 8 runtime
- add `JwtSettings` to `appsettings.json`
- configure JWT authentication with symmetric key in `Program.cs`
- use the same key when generating tokens in `AuthService`
- add authorization services

## Testing
- `dotnet build GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_68518406f4b08323b3d343cacd1033ec