### PR TITLE
Configure SmartCors for localhost

### DIFF
--- a/Server.Api/Server.Api/Program.cs
+++ b/Server.Api/Server.Api/Program.cs
@@ -81,9 +81,11 @@ builder.Services.AddAuthorization();
 // CORS configuration
 builder.Services.AddCors(options =>
 {
-    options.AddPolicy("AllowWasmDev", policy =>
+    options.AddPolicy("SmartCors", policy =>
     {
-        policy.WithOrigins("https://localhost:7197")
+        policy.SetIsOriginAllowed(origin =>
+                origin.StartsWith("http://localhost") ||
+                origin.StartsWith("https://localhost"))
               .AllowAnyHeader()
               .AllowAnyMethod()
               .AllowCredentials();
@@ -152,7 +154,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseRouting();
 
-app.UseCors("AllowWasmDev");
+app.UseCors("SmartCors");
 
 app.UseAuthentication();
 app.UseAuthorization();


### PR DESCRIPTION
## Summary
- update CORS settings to `SmartCors`
- enable dynamic origin matching for localhost

## Testing
- `dotnet build GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_685187246d9c8323a3c8b9d98826c15c