### PR TITLE
Fix login deserialization and add JSON error handling

### DIFF
--- a/Client.Wasm/Client.Wasm/Services/AuthService.cs
+++ b/Client.Wasm/Client.Wasm/Services/AuthService.cs
@@ -23,15 +23,23 @@ public class AuthService : IAuthService
     public async Task<bool> LoginAsync(LoginRequestDto dto)
     {
         var res = await _http.PostAsJsonAsync("api/auth/login", dto);
+
         if (!res.IsSuccessStatusCode)
         {
             return false;
         }
+
+        if (res.Content == null || res.Content.Headers.ContentLength == 0)
+        {
+            return false;
+        }
+
         var result = await res.Content.ReadFromJsonAsync<AuthResultDto>();
         if (result == null)
         {
             return false;
         }
+
         await _authProvider.SetTokenAsync(result.Token);
         return true;
     }

--- a/Server.Api/Server.Api/Controllers/AuthController.cs
+++ b/Server.Api/Server.Api/Controllers/AuthController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using GovServices.Server.Interfaces;
+using GovServices.Server.DTOs;
 
 namespace GovServices.Server.Controllers;
 
@@ -17,8 +18,16 @@ public class AuthController : ControllerBase
 
     [HttpPost("login")]
     [AllowAnonymous]
-    public IActionResult Login()
+    public async Task<IActionResult> Login([FromBody] LoginRequestDto dto)
     {
-        return Ok();
+        try
+        {
+            var result = await _auth.LoginAsync(dto);
+            return Ok(result);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Unauthorized(new { error = "Invalid credentials" });
+        }
     }
 }

--- a/Server.Api/Server.Api/Controllers/ErrorController.cs
+++ b/Server.Api/Server.Api/Controllers/ErrorController.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+public class ErrorController : ControllerBase
+{
+    [Route("/error")]
+    public IActionResult HandleError()
+    {
+        var exceptionHandlerFeature = HttpContext.Features.Get<IExceptionHandlerFeature>();
+        var exception = exceptionHandlerFeature?.Error;
+        return Problem(detail: exception?.Message, statusCode: 500);
+    }
+}

--- a/Server.Api/Server.Api/Interfaces/IAuthService.cs
+++ b/Server.Api/Server.Api/Interfaces/IAuthService.cs
@@ -1,3 +1,9 @@
 namespace GovServices.Server.Interfaces;
 
-public interface IAuthService { }
+using GovServices.Server.DTOs;
+
+public interface IAuthService
+{
+    Task<AuthResultDto> LoginAsync(LoginRequestDto dto);
+    Task<bool> RefreshTokenAsync(string refreshToken);
+}

--- a/Server.Api/Server.Api/Program.cs
+++ b/Server.Api/Server.Api/Program.cs
@@ -150,6 +150,8 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
+app.UseExceptionHandler("/error");
+
 // app.UseHttpsRedirection(); // Disabled for local development
 
 app.UseRouting();


### PR DESCRIPTION
## Summary
- avoid crashes when login API returns empty body
- return login result JSON from `AuthController`
- expose `LoginAsync` in `IAuthService`
- handle API exceptions with `/error` endpoint

## Testing
- `dotnet build GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_685188a6bbc883239abdb49a08391a8a