### PR TITLE
Add permission groups and auth seeding

### DIFF
--- a/Client.Wasm/Client.Wasm/DTOs/PermissionGroupDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/PermissionGroupDto.cs
@@ -1,0 +1,8 @@
+namespace Client.Wasm.DTOs;
+
+public class PermissionGroupDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public List<string> Permissions { get; set; } = new();
+}

--- a/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
+++ b/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
@@ -66,7 +66,8 @@
         new MenuItem { Text = "Applications", Url = "/applications" },
         new MenuItem { Text = "Documents", Url = "/documents/0" },
         new MenuItem { Text = "Templates", Url = "/templates" },
-        new MenuItem { Text = "Users", Url = "/users" }
+        new MenuItem { Text = "Users", Url = "/users" },
+        new MenuItem { Text = "Permission Groups", Url = "/permission-groups" }
     };
 
     private async Task Logout()

--- a/Client.Wasm/Client.Wasm/Pages/PermissionGroups.razor
+++ b/Client.Wasm/Client.Wasm/Pages/PermissionGroups.razor
@@ -1,0 +1,29 @@
+@page "/permission-groups"
+@attribute [Authorize(Roles="Администратор")]
+@inject IPermissionGroupApiClient Api
+@using Client.Wasm.DTOs
+@using Syncfusion.Blazor.Grids
+@using Microsoft.AspNetCore.Authorization
+
+<SfCard CssClass="mb-4">
+    <CardHeader><h1>Группы прав</h1></CardHeader>
+    <CardContent>
+        <SfGrid DataSource="groups" AllowPaging="true" Width="100%">
+            <GridColumns>
+                <GridColumn Field="Id" HeaderText="ID" Width="100" TextAlign="TextAlign.Center" />
+                <GridColumn Field="Name" HeaderText="Название" Width="200" />
+                <GridColumn HeaderText="Права" Width="300">
+                    <Template>@string.Join(", ", (context as PermissionGroupDto).Permissions)</Template>
+                </GridColumn>
+            </GridColumns>
+        </SfGrid>
+    </CardContent>
+</SfCard>
+
+@code {
+    List<PermissionGroupDto> groups = new();
+    protected override async Task OnInitializedAsync()
+    {
+        groups = await Api.GetAllAsync();
+    }
+}

--- a/Client.Wasm/Client.Wasm/Services/PermissionGroupApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/PermissionGroupApiClient.cs
@@ -1,0 +1,24 @@
+namespace Client.Wasm.Services;
+
+using System.Net.Http.Json;
+using Client.Wasm.DTOs;
+
+public interface IPermissionGroupApiClient
+{
+    Task<List<PermissionGroupDto>> GetAllAsync();
+}
+
+public class PermissionGroupApiClient : IPermissionGroupApiClient
+{
+    private readonly HttpClient _http;
+
+    public PermissionGroupApiClient(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<List<PermissionGroupDto>> GetAllAsync()
+    {
+        return await _http.GetFromJsonAsync<List<PermissionGroupDto>>("api/permissiongroups") ?? new();
+    }
+}

--- a/Client.Wasm/Client.Wasm/wwwroot/css/app.css
+++ b/Client.Wasm/Client.Wasm/wwwroot/css/app.css
@@ -113,3 +113,7 @@ code {
 }
 
 .e-primary{background-color:#FF8C00;border-color:#FF8C00;}
+
+body { font-family: "Inter", "Segoe UI", sans-serif; font-size: 16px; color:#1f2937; background:#fff; }
+.sf-card { border-radius: 0.75rem; padding:1.5rem; box-shadow:0 2px 8px rgba(0,0,0,0.05); backdrop-filter: blur(12px); background: rgba(255,255,255,0.8); }
+

--- a/Server.Api/Server.Api/Authorization/PermissionNames.cs
+++ b/Server.Api/Server.Api/Authorization/PermissionNames.cs
@@ -1,0 +1,14 @@
+namespace GovServices.Server.Authorization;
+
+public static class PermissionNames
+{
+    public const string AccessRDZ = "Доступ к РДЗ";
+    public const string AccessRDI = "Доступ к РДИ";
+    public const string RequestEGRN = "Запросы в ЕГРН";
+    public const string RequestVIS = "Запросы в ВИС";
+    public const string RequestZAGS = "Запросы в ЗАГС";
+    public const string UploadDocuments = "Доступ к загрузке документов";
+    public const string SignDocuments = "Доступ к подписанию документов";
+    public const string ViewSpecificServices = "Доступ только к определённым госуслугам";
+    public const string ViewClosedServices = "Доступ только к закрытым услугам";
+}

--- a/Server.Api/Server.Api/Authorization/RoleNames.cs
+++ b/Server.Api/Server.Api/Authorization/RoleNames.cs
@@ -1,0 +1,13 @@
+namespace GovServices.Server.Authorization;
+
+public static class RoleNames
+{
+    public const string Administrator = "Администратор";
+    public const string Registrar = "Регистратор";
+    public const string Analyst = "Аналитик";
+    public const string Lawyer = "Юрист";
+    public const string DepartmentHead = "Начальник отдела";
+    public const string ManagementHead = "Начальник управления";
+    public const string Director = "Директор";
+    public const string Executor = "Исполнитель";
+}

--- a/Server.Api/Server.Api/Controllers/PermissionGroupsController.cs
+++ b/Server.Api/Server.Api/Controllers/PermissionGroupsController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using GovServices.Server.Data;
+using GovServices.Server.DTOs;
+using GovServices.Server.Entities;
+using System.Collections.Generic;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class PermissionGroupsController : ControllerBase
+{
+    private readonly ApplicationDbContext _context;
+
+    public PermissionGroupsController(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    [HttpGet]
+    public async Task<IEnumerable<PermissionGroupDto>> Get()
+    {
+        return await _context.PermissionGroups
+            .Include(g => g.PermissionGroupPermissions)
+                .ThenInclude(p => p.Permission)
+            .Select(g => new PermissionGroupDto
+            {
+                Id = g.Id,
+                Name = g.Name,
+                Permissions = g.PermissionGroupPermissions.Select(p => p.Permission.Name).ToList()
+            })
+            .ToListAsync();
+    }
+}

--- a/Server.Api/Server.Api/DTOs/CreateUserDto.cs
+++ b/Server.Api/Server.Api/DTOs/CreateUserDto.cs
@@ -6,5 +6,6 @@ namespace GovServices.Server.DTOs
         public string FullName { get; set; }
         public int DepartmentId { get; set; }
         public List<string> RoleIds { get; set; }
+        public List<int> GroupIds { get; set; }
     }
 }

--- a/Server.Api/Server.Api/DTOs/PermissionGroupDto.cs
+++ b/Server.Api/Server.Api/DTOs/PermissionGroupDto.cs
@@ -1,0 +1,8 @@
+namespace GovServices.Server.DTOs;
+
+public class PermissionGroupDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public List<string> Permissions { get; set; }
+}

--- a/Server.Api/Server.Api/DTOs/UpdateUserDto.cs
+++ b/Server.Api/Server.Api/DTOs/UpdateUserDto.cs
@@ -5,5 +5,6 @@ namespace GovServices.Server.DTOs
         public string FullName { get; set; }
         public int DepartmentId { get; set; }
         public List<string> RoleIds { get; set; }
+        public List<int> GroupIds { get; set; }
     }
 }

--- a/Server.Api/Server.Api/DTOs/UserDto.cs
+++ b/Server.Api/Server.Api/DTOs/UserDto.cs
@@ -7,5 +7,6 @@ namespace GovServices.Server.DTOs
         public string FullName { get; set; }
         public List<string> Roles { get; set; }
         public string DepartmentName { get; set; }
+        public List<string> Groups { get; set; }
     }
 }

--- a/Server.Api/Server.Api/Data/ApplicationDbContext.cs
+++ b/Server.Api/Server.Api/Data/ApplicationDbContext.cs
@@ -28,11 +28,39 @@ namespace GovServices.Server.Data
         public DbSet<AuditLog> AuditLogs { get; set; }
         public DbSet<PasswordChangeLog> PasswordChangeLogs { get; set; }
         public DbSet<Department> Departments { get; set; }
+        public DbSet<Permission> Permissions { get; set; }
+        public DbSet<PermissionGroup> PermissionGroups { get; set; }
+        public DbSet<PermissionGroupPermission> PermissionGroupPermissions { get; set; }
+        public DbSet<UserPermissionGroup> UserPermissionGroups { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
             base.OnModelCreating(builder);
-            // здесь можно добавить конфигурацию связей и ограничений, если надо
+            builder.Entity<UserPermissionGroup>()
+                .HasKey(upg => new { upg.UserId, upg.PermissionGroupId });
+
+            builder.Entity<UserPermissionGroup>()
+                .HasOne(upg => upg.User)
+                .WithMany(u => u.PermissionGroups)
+                .HasForeignKey(upg => upg.UserId);
+
+            builder.Entity<UserPermissionGroup>()
+                .HasOne(upg => upg.PermissionGroup)
+                .WithMany(pg => pg.UserPermissionGroups)
+                .HasForeignKey(upg => upg.PermissionGroupId);
+
+            builder.Entity<PermissionGroupPermission>()
+                .HasKey(pgp => new { pgp.PermissionGroupId, pgp.PermissionId });
+
+            builder.Entity<PermissionGroupPermission>()
+                .HasOne(pgp => pgp.PermissionGroup)
+                .WithMany(pg => pg.PermissionGroupPermissions)
+                .HasForeignKey(pgp => pgp.PermissionGroupId);
+
+            builder.Entity<PermissionGroupPermission>()
+                .HasOne(pgp => pgp.Permission)
+                .WithMany(p => p.PermissionGroupPermissions)
+                .HasForeignKey(pgp => pgp.PermissionId);
         }
     }
 }

--- a/Server.Api/Server.Api/Data/DataSeeder.cs
+++ b/Server.Api/Server.Api/Data/DataSeeder.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Identity;
 using GovServices.Server.Entities;
+using GovServices.Server.Authorization;
 
 namespace GovServices.Server.Data
 {
@@ -9,14 +10,65 @@ namespace GovServices.Server.Data
         {
             var userManager = services.GetRequiredService<UserManager<ApplicationUser>>();
             var roleManager = services.GetRequiredService<RoleManager<IdentityRole>>();
+            var context = services.GetRequiredService<ApplicationDbContext>();
 
-            const string adminRole = "Administrator";
+            var roles = new[]
+            {
+                RoleNames.Administrator,
+                RoleNames.Registrar,
+                RoleNames.Analyst,
+                RoleNames.Lawyer,
+                RoleNames.DepartmentHead,
+                RoleNames.ManagementHead,
+                RoleNames.Director,
+                RoleNames.Executor
+            };
             const string adminEmail = "admin@gosuslugi.local";
             const string adminPassword = "P@ssw0rd123";
-
-            if (!await roleManager.RoleExistsAsync(adminRole))
+            foreach (var role in roles)
             {
-                await roleManager.CreateAsync(new IdentityRole(adminRole));
+                if (!await roleManager.RoleExistsAsync(role))
+                {
+                    await roleManager.CreateAsync(new IdentityRole(role));
+                }
+            }
+
+            var permissions = new[]
+            {
+                PermissionNames.AccessRDZ,
+                PermissionNames.AccessRDI,
+                PermissionNames.RequestEGRN,
+                PermissionNames.RequestVIS,
+                PermissionNames.RequestZAGS,
+                PermissionNames.UploadDocuments,
+                PermissionNames.SignDocuments,
+                PermissionNames.ViewSpecificServices,
+                PermissionNames.ViewClosedServices
+            };
+
+            foreach (var perm in permissions)
+            {
+                if (!context.Permissions.Any(p => p.Name == perm))
+                    context.Permissions.Add(new Permission { Name = perm });
+            }
+            await context.SaveChangesAsync();
+
+            var fullGroup = context.PermissionGroups.FirstOrDefault(g => g.Name == "Полный доступ");
+            if (fullGroup == null)
+            {
+                fullGroup = new PermissionGroup { Name = "Полный доступ" };
+                context.PermissionGroups.Add(fullGroup);
+                await context.SaveChangesAsync();
+
+                foreach (var perm in context.Permissions)
+                {
+                    context.PermissionGroupPermissions.Add(new PermissionGroupPermission
+                    {
+                        PermissionGroupId = fullGroup.Id,
+                        PermissionId = perm.Id
+                    });
+                }
+                await context.SaveChangesAsync();
             }
 
             var admin = await userManager.FindByEmailAsync(adminEmail);
@@ -33,8 +85,18 @@ namespace GovServices.Server.Data
                 var result = await userManager.CreateAsync(admin, adminPassword);
                 if (result.Succeeded)
                 {
-                    await userManager.AddToRoleAsync(admin, adminRole);
+                    await userManager.AddToRoleAsync(admin, RoleNames.Administrator);
                 }
+            }
+
+            if (!context.UserPermissionGroups.Any(upg => upg.UserId == admin.Id && upg.PermissionGroupId == fullGroup.Id))
+            {
+                context.UserPermissionGroups.Add(new UserPermissionGroup
+                {
+                    UserId = admin.Id,
+                    PermissionGroupId = fullGroup.Id
+                });
+                await context.SaveChangesAsync();
             }
         }
     }

--- a/Server.Api/Server.Api/Entities/ApplicationUser.cs
+++ b/Server.Api/Server.Api/Entities/ApplicationUser.cs
@@ -8,5 +8,6 @@ namespace GovServices.Server.Entities
         public Department Department { get; set; }
         public DateTime PasswordLastChangedAt { get; set; }
         public ICollection<Application> AssignedApplications { get; set; }
+        public ICollection<UserPermissionGroup> PermissionGroups { get; set; }
     }
 }

--- a/Server.Api/Server.Api/Entities/Permission.cs
+++ b/Server.Api/Server.Api/Entities/Permission.cs
@@ -1,0 +1,8 @@
+namespace GovServices.Server.Entities;
+
+public class Permission
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public ICollection<PermissionGroupPermission> PermissionGroupPermissions { get; set; }
+}

--- a/Server.Api/Server.Api/Entities/PermissionGroup.cs
+++ b/Server.Api/Server.Api/Entities/PermissionGroup.cs
@@ -1,0 +1,9 @@
+namespace GovServices.Server.Entities;
+
+public class PermissionGroup
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public ICollection<PermissionGroupPermission> PermissionGroupPermissions { get; set; }
+    public ICollection<UserPermissionGroup> UserPermissionGroups { get; set; }
+}

--- a/Server.Api/Server.Api/Entities/PermissionGroupPermission.cs
+++ b/Server.Api/Server.Api/Entities/PermissionGroupPermission.cs
@@ -1,0 +1,9 @@
+namespace GovServices.Server.Entities;
+
+public class PermissionGroupPermission
+{
+    public int PermissionGroupId { get; set; }
+    public PermissionGroup PermissionGroup { get; set; }
+    public int PermissionId { get; set; }
+    public Permission Permission { get; set; }
+}

--- a/Server.Api/Server.Api/Entities/UserPermissionGroup.cs
+++ b/Server.Api/Server.Api/Entities/UserPermissionGroup.cs
@@ -1,0 +1,9 @@
+namespace GovServices.Server.Entities;
+
+public class UserPermissionGroup
+{
+    public string UserId { get; set; }
+    public ApplicationUser User { get; set; }
+    public int PermissionGroupId { get; set; }
+    public PermissionGroup PermissionGroup { get; set; }
+}

--- a/Server.Api/Server.Api/Services/AuthService.cs
+++ b/Server.Api/Server.Api/Services/AuthService.cs
@@ -3,6 +3,8 @@ using System.Security.Claims;
 using System.Text;
 using GovServices.Server.DTOs;
 using GovServices.Server.Entities;
+using GovServices.Server.Data;
+using Microsoft.EntityFrameworkCore;
 using GovServices.Server.Interfaces;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
@@ -15,14 +17,17 @@ public class AuthService : IAuthService
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly SignInManager<ApplicationUser> _signInManager;
     private readonly IConfiguration _configuration;
+    private readonly ApplicationDbContext _context;
 
     public AuthService(UserManager<ApplicationUser> userManager,
         SignInManager<ApplicationUser> signInManager,
-        IConfiguration configuration)
+        IConfiguration configuration,
+        ApplicationDbContext context)
     {
         _userManager = userManager;
         _signInManager = signInManager;
         _configuration = configuration;
+        _context = context;
     }
 
     public async Task<AuthResultDto> LoginAsync(LoginRequestDto dto)
@@ -55,6 +60,19 @@ public class AuthService : IAuthService
 
         var roles = await _userManager.GetRolesAsync(user);
         claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+
+        var groupIds = await _context.UserPermissionGroups
+            .Where(g => g.UserId == user.Id)
+            .Select(g => g.PermissionGroupId)
+            .ToListAsync();
+
+        var permissions = await _context.PermissionGroupPermissions
+            .Where(p => groupIds.Contains(p.PermissionGroupId))
+            .Select(p => p.Permission.Name)
+            .Distinct()
+            .ToListAsync();
+
+        claims.AddRange(permissions.Select(p => new Claim("perm", p)));
 
         var duration = 60; // токен действует 1 час
 


### PR DESCRIPTION
## Summary
- add role and permission constants
- implement permission group entities with EF relationships
- seed roles, permissions, and admin with full permissions
- expose permission groups via controller and return claims with permissions
- extend user DTOs and services to handle permission groups
- show permission groups in Blazor app and minimal modern style

## Testing
- `dotnet build GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_68518d489b8c83239e6777d197d7c540