### PR TITLE
Add registry pages and new roles

### DIFF
--- a/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
+++ b/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
@@ -67,7 +67,15 @@
         new MenuItem { Text = "Documents", Url = "/documents/0" },
         new MenuItem { Text = "Templates", Url = "/templates" },
         new MenuItem { Text = "Users", Url = "/users" },
-        new MenuItem { Text = "Permission Groups", Url = "/permission-groups" }
+        new MenuItem { Text = "Permission Groups", Url = "/permission-groups" },
+        new MenuItem { Text = "Актуальные заявления", Url = "/registry/applications" },
+        new MenuItem { Text = "Распоряжения РДЗ", Url = "/registry/rdz-orders" },
+        new MenuItem { Text = "Распоряжения РДИ", Url = "/registry/rdi-orders" },
+        new MenuItem { Text = "Ответы", Url = "/registry/answers" },
+        new MenuItem { Text = "Договоры", Url = "/registry/contracts" },
+        new MenuItem { Text = "Акты", Url = "/registry/acts" },
+        new MenuItem { Text = "Соглашения", Url = "/registry/agreements" },
+        new MenuItem { Text = "Канцелярия", Url = "/registry/clerical" }
     };
 
     private async Task Logout()

--- a/Client.Wasm/Client.Wasm/Pages/RegistryActs.razor
+++ b/Client.Wasm/Client.Wasm/Pages/RegistryActs.razor
@@ -1,0 +1,33 @@
+@page "/registry/acts"
+@attribute [Authorize]
+
+<SfCard CssClass="glass-effect rounded-xl shadow-lg p-6 mb-4">
+    <CardHeader>
+        <h1>Акты</h1>
+    </CardHeader>
+    <CardContent>
+        <SfGrid DataSource="@acts" AllowPaging="true" AllowSorting="true" AllowExcelExport="true" AllowPdfExport="true" Toolbar="@toolbar" CssClass="e-bootstrap5">
+            <GridPageSettings PageSize="10" />
+            <GridColumns>
+                <GridColumn Field=@nameof(ActRow.Id) HeaderText="ID" Width="80" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
+                <GridColumn Field=@nameof(ActRow.Name) HeaderText="Название" Width="200" />
+            </GridColumns>
+        </SfGrid>
+    </CardContent>
+</SfCard>
+
+@code {
+    List<ActRow> acts = new();
+    string[] toolbar = new[] { "Search", "ExcelExport", "PdfExport" };
+
+    protected override void OnInitialized()
+    {
+        acts = new() { new ActRow { Id = 1, Name = "Акт №1" } };
+    }
+
+    class ActRow
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/Client.Wasm/Client.Wasm/Pages/RegistryAgreements.razor
+++ b/Client.Wasm/Client.Wasm/Pages/RegistryAgreements.razor
@@ -1,0 +1,33 @@
+@page "/registry/agreements"
+@attribute [Authorize]
+
+<SfCard CssClass="glass-effect rounded-xl shadow-lg p-6 mb-4">
+    <CardHeader>
+        <h1>Соглашения</h1>
+    </CardHeader>
+    <CardContent>
+        <SfGrid DataSource="@agreements" AllowPaging="true" AllowSorting="true" AllowExcelExport="true" AllowPdfExport="true" Toolbar="@toolbar" CssClass="e-bootstrap5">
+            <GridPageSettings PageSize="10" />
+            <GridColumns>
+                <GridColumn Field=@nameof(AgreementRow.Id) HeaderText="ID" Width="80" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
+                <GridColumn Field=@nameof(AgreementRow.Name) HeaderText="Название" Width="200" />
+            </GridColumns>
+        </SfGrid>
+    </CardContent>
+</SfCard>
+
+@code {
+    List<AgreementRow> agreements = new();
+    string[] toolbar = new[] { "Search", "ExcelExport", "PdfExport" };
+
+    protected override void OnInitialized()
+    {
+        agreements = new() { new AgreementRow { Id = 1, Name = "Соглашение №1" } };
+    }
+
+    class AgreementRow
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/Client.Wasm/Client.Wasm/Pages/RegistryAnswers.razor
+++ b/Client.Wasm/Client.Wasm/Pages/RegistryAnswers.razor
@@ -1,0 +1,33 @@
+@page "/registry/answers"
+@attribute [Authorize]
+
+<SfCard CssClass="glass-effect rounded-xl shadow-lg p-6 mb-4">
+    <CardHeader>
+        <h1>Ответы</h1>
+    </CardHeader>
+    <CardContent>
+        <SfGrid DataSource="@answers" AllowPaging="true" AllowSorting="true" AllowExcelExport="true" AllowPdfExport="true" Toolbar="@toolbar" CssClass="e-bootstrap5">
+            <GridPageSettings PageSize="10" />
+            <GridColumns>
+                <GridColumn Field=@nameof(AnswerRow.Id) HeaderText="ID" Width="80" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
+                <GridColumn Field=@nameof(AnswerRow.Subject) HeaderText="Тема" Width="200" />
+            </GridColumns>
+        </SfGrid>
+    </CardContent>
+</SfCard>
+
+@code {
+    List<AnswerRow> answers = new();
+    string[] toolbar = new[] { "Search", "ExcelExport", "PdfExport" };
+
+    protected override void OnInitialized()
+    {
+        answers = new() { new AnswerRow { Id = 1, Subject = "Ответ по заявлению" } };
+    }
+
+    class AnswerRow
+    {
+        public int Id { get; set; }
+        public string Subject { get; set; } = string.Empty;
+    }
+}

--- a/Client.Wasm/Client.Wasm/Pages/RegistryApplications.razor
+++ b/Client.Wasm/Client.Wasm/Pages/RegistryApplications.razor
@@ -1,0 +1,36 @@
+@page "/registry/applications"
+@attribute [Authorize]
+
+<SfCard CssClass="glass-effect rounded-xl shadow-lg p-6 mb-4">
+    <CardHeader>
+        <h1>Актуальные заявления</h1>
+    </CardHeader>
+    <CardContent>
+        <SfGrid DataSource="@applications" AllowPaging="true" AllowSorting="true" AllowExcelExport="true" AllowPdfExport="true" Toolbar="@toolbar" CssClass="e-bootstrap5">
+            <GridPageSettings PageSize="10" />
+            <GridColumns>
+                <GridColumn Field=@nameof(ApplicationRow.Id) HeaderText="ID" Width="80" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
+                <GridColumn Field=@nameof(ApplicationRow.Name) HeaderText="Название" Width="200" />
+            </GridColumns>
+        </SfGrid>
+    </CardContent>
+</SfCard>
+
+@code {
+    List<ApplicationRow> applications = new();
+    string[] toolbar = new[] { "Search", "ExcelExport", "PdfExport" };
+
+    protected override void OnInitialized()
+    {
+        applications = new()
+        {
+            new ApplicationRow { Id = 1, Name = "Пример" }
+        };
+    }
+
+    class ApplicationRow
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/Client.Wasm/Client.Wasm/Pages/RegistryClerical.razor
+++ b/Client.Wasm/Client.Wasm/Pages/RegistryClerical.razor
@@ -1,0 +1,60 @@
+@page "/registry/clerical"
+@attribute [Authorize(Roles = "Канцелярия")]
+
+<SfCard CssClass="glass-effect rounded-xl shadow-lg p-6 mb-4">
+    <CardHeader>
+        <h1>Реестр канцелярии</h1>
+    </CardHeader>
+    <CardContent>
+        <SfButton CssClass="e-primary mb-4" OnClick="ShowDialog">Зарегистрировать ответ</SfButton>
+        <SfGrid DataSource="@answers" AllowPaging="true" AllowSorting="true" AllowExcelExport="true" AllowPdfExport="true" Toolbar="@toolbar" CssClass="e-bootstrap5">
+            <GridPageSettings PageSize="10" />
+            <GridColumns>
+                <GridColumn Field=@nameof(AnswerRow.Id) HeaderText="ID" Width="80" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
+                <GridColumn Field=@nameof(AnswerRow.Subject) HeaderText="Тема" Width="200" />
+            </GridColumns>
+        </SfGrid>
+        <SfDialog Width="450px" IsModal="true" ShowCloseIcon="true" Visible="@dialogVisible" Header="Регистрация ответа" CssClass="e-bootstrap5">
+            <EditForm Model="newAnswer" OnValidSubmit="Save">
+                <DataAnnotationsValidator />
+                <ValidationSummary />
+                <SfTextBox @bind-Value="newAnswer.Subject" Placeholder="Тема" CssClass="form-field" />
+                <SfUploader AutoUpload="false" CssClass="form-field" />
+                <div class="text-right">
+                    <SfButton Type="Submit" CssClass="e-primary me-2">Сохранить</SfButton>
+                    <SfButton CssClass="e-flat" OnClick="HideDialog">Отмена</SfButton>
+                </div>
+            </EditForm>
+        </SfDialog>
+    </CardContent>
+</SfCard>
+
+@code {
+    List<AnswerRow> answers = new();
+    bool dialogVisible;
+    AnswerRow newAnswer = new();
+    string[] toolbar = new[] { "Search", "ExcelExport", "PdfExport" };
+
+    protected override void OnInitialized()
+    {
+        answers = new() { new AnswerRow { Id = 1, Subject = "Получен ответ" } };
+    }
+
+    void ShowDialog() => dialogVisible = true;
+    void HideDialog() => dialogVisible = false;
+
+    Task Save()
+    {
+        dialogVisible = false;
+        answers.Add(new AnswerRow { Id = answers.Count + 1, Subject = newAnswer.Subject });
+        newAnswer = new();
+        return Task.CompletedTask;
+    }
+
+    class AnswerRow
+    {
+        public int Id { get; set; }
+        [Required]
+        public string Subject { get; set; } = string.Empty;
+    }
+}

--- a/Client.Wasm/Client.Wasm/Pages/RegistryContracts.razor
+++ b/Client.Wasm/Client.Wasm/Pages/RegistryContracts.razor
@@ -1,0 +1,33 @@
+@page "/registry/contracts"
+@attribute [Authorize]
+
+<SfCard CssClass="glass-effect rounded-xl shadow-lg p-6 mb-4">
+    <CardHeader>
+        <h1>Договоры</h1>
+    </CardHeader>
+    <CardContent>
+        <SfGrid DataSource="@contracts" AllowPaging="true" AllowSorting="true" AllowExcelExport="true" AllowPdfExport="true" Toolbar="@toolbar" CssClass="e-bootstrap5">
+            <GridPageSettings PageSize="10" />
+            <GridColumns>
+                <GridColumn Field=@nameof(ContractRow.Id) HeaderText="ID" Width="80" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
+                <GridColumn Field=@nameof(ContractRow.Name) HeaderText="Название" Width="200" />
+            </GridColumns>
+        </SfGrid>
+    </CardContent>
+</SfCard>
+
+@code {
+    List<ContractRow> contracts = new();
+    string[] toolbar = new[] { "Search", "ExcelExport", "PdfExport" };
+
+    protected override void OnInitialized()
+    {
+        contracts = new() { new ContractRow { Id = 1, Name = "Договор №1" } };
+    }
+
+    class ContractRow
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/Client.Wasm/Client.Wasm/Pages/RegistryRdiOrders.razor
+++ b/Client.Wasm/Client.Wasm/Pages/RegistryRdiOrders.razor
@@ -1,0 +1,33 @@
+@page "/registry/rdi-orders"
+@attribute [Authorize]
+
+<SfCard CssClass="glass-effect rounded-xl shadow-lg p-6 mb-4">
+    <CardHeader>
+        <h1>Распоряжения РДИ</h1>
+    </CardHeader>
+    <CardContent>
+        <SfGrid DataSource="@orders" AllowPaging="true" AllowSorting="true" AllowExcelExport="true" AllowPdfExport="true" Toolbar="@toolbar" CssClass="e-bootstrap5">
+            <GridPageSettings PageSize="10" />
+            <GridColumns>
+                <GridColumn Field=@nameof(OrderRow.Id) HeaderText="ID" Width="80" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
+                <GridColumn Field=@nameof(OrderRow.Number) HeaderText="Номер" Width="120" />
+            </GridColumns>
+        </SfGrid>
+    </CardContent>
+</SfCard>
+
+@code {
+    List<OrderRow> orders = new();
+    string[] toolbar = new[] { "Search", "ExcelExport", "PdfExport" };
+
+    protected override void OnInitialized()
+    {
+        orders = new() { new OrderRow { Id = 1, Number = "01-РДИ" } };
+    }
+
+    class OrderRow
+    {
+        public int Id { get; set; }
+        public string Number { get; set; } = string.Empty;
+    }
+}

--- a/Client.Wasm/Client.Wasm/Pages/RegistryRdzOrders.razor
+++ b/Client.Wasm/Client.Wasm/Pages/RegistryRdzOrders.razor
@@ -1,0 +1,33 @@
+@page "/registry/rdz-orders"
+@attribute [Authorize]
+
+<SfCard CssClass="glass-effect rounded-xl shadow-lg p-6 mb-4">
+    <CardHeader>
+        <h1>Распоряжения РДЗ</h1>
+    </CardHeader>
+    <CardContent>
+        <SfGrid DataSource="@orders" AllowPaging="true" AllowSorting="true" AllowExcelExport="true" AllowPdfExport="true" Toolbar="@toolbar" CssClass="e-bootstrap5">
+            <GridPageSettings PageSize="10" />
+            <GridColumns>
+                <GridColumn Field=@nameof(OrderRow.Id) HeaderText="ID" Width="80" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
+                <GridColumn Field=@nameof(OrderRow.Number) HeaderText="Номер" Width="120" />
+            </GridColumns>
+        </SfGrid>
+    </CardContent>
+</SfCard>
+
+@code {
+    List<OrderRow> orders = new();
+    string[] toolbar = new[] { "Search", "ExcelExport", "PdfExport" };
+
+    protected override void OnInitialized()
+    {
+        orders = new() { new OrderRow { Id = 1, Number = "01-РДЗ" } };
+    }
+
+    class OrderRow
+    {
+        public int Id { get; set; }
+        public string Number { get; set; } = string.Empty;
+    }
+}

--- a/Client.Wasm/Client.Wasm/wwwroot/css/site.css
+++ b/Client.Wasm/Client.Wasm/wwwroot/css/site.css
@@ -38,6 +38,22 @@ html, body {
     backdrop-filter: blur(14px);
 }
 
+.rounded-xl {
+    border-radius: 1rem;
+}
+
+.shadow-lg {
+    box-shadow: 0 20px 40px rgba(0,0,0,0.1);
+}
+
+.p-6 {
+    padding: 1.5rem;
+}
+
+.mb-4 {
+    margin-bottom: 1rem;
+}
+
 .login-logo {
     height: 48px;
     margin-bottom: 1rem;

--- a/Server.Api/Server.Api/Authorization/RoleNames.cs
+++ b/Server.Api/Server.Api/Authorization/RoleNames.cs
@@ -9,5 +9,15 @@ public static class RoleNames
     public const string DepartmentHead = "Начальник отдела";
     public const string ManagementHead = "Начальник управления";
     public const string Director = "Директор";
+    public const string FirstDeputyDirector = "Первый заместитель директора";
     public const string Executor = "Исполнитель";
+    public const string Chancery = "Канцелярия";
+    public const string Egrn = "ЕГРН";
+    public const string Vis = "ВИС";
+    public const string Zags = "ЗАГС";
+    public const string DocumentUpload = "Загрузка документов";
+    public const string DocumentSign = "Подписание документов";
+    public const string Rdz = "РДЗ";
+    public const string Rdi = "РДИ";
+    public const string ClosedServices = "Доступ к закрытым услугам";
 }

--- a/Server.Api/Server.Api/Controllers/RegistriesController.cs
+++ b/Server.Api/Server.Api/Controllers/RegistriesController.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class RegistriesController : ControllerBase
+{
+    [Authorize]
+    [HttpGet("applications")]
+    public IActionResult Applications() => Ok(new[] { new { Id = 1, Name = "Пример" } });
+
+    [Authorize]
+    [HttpGet("rdz-orders")]
+    public IActionResult RdzOrders() => Ok(new[] { new { Id = 1, Number = "01-РДЗ" } });
+
+    [Authorize]
+    [HttpGet("rdi-orders")]
+    public IActionResult RdiOrders() => Ok(new[] { new { Id = 1, Number = "01-РДИ" } });
+
+    [Authorize]
+    [HttpGet("answers")]
+    public IActionResult Answers() => Ok(new[] { new { Id = 1, Subject = "Ответ" } });
+
+    [Authorize]
+    [HttpGet("contracts")]
+    public IActionResult Contracts() => Ok(new[] { new { Id = 1, Name = "Договор" } });
+
+    [Authorize]
+    [HttpGet("acts")]
+    public IActionResult Acts() => Ok(new[] { new { Id = 1, Name = "Акт" } });
+
+    [Authorize]
+    [HttpGet("agreements")]
+    public IActionResult Agreements() => Ok(new[] { new { Id = 1, Name = "Соглашение" } });
+
+    [Authorize(Roles = "Канцелярия")]
+    [HttpGet("clerical")]
+    public IActionResult Clerical() => Ok(new[] { new { Id = 1, Subject = "Получен ответ" } });
+}

--- a/Server.Api/Server.Api/Data/DataSeeder.cs
+++ b/Server.Api/Server.Api/Data/DataSeeder.cs
@@ -21,7 +21,17 @@ namespace GovServices.Server.Data
                 RoleNames.DepartmentHead,
                 RoleNames.ManagementHead,
                 RoleNames.Director,
-                RoleNames.Executor
+                RoleNames.FirstDeputyDirector,
+                RoleNames.Executor,
+                RoleNames.Chancery,
+                RoleNames.Egrn,
+                RoleNames.Vis,
+                RoleNames.Zags,
+                RoleNames.DocumentUpload,
+                RoleNames.DocumentSign,
+                RoleNames.Rdz,
+                RoleNames.Rdi,
+                RoleNames.ClosedServices
             };
             const string adminEmail = "admin@gosuslugi.local";
             const string adminPassword = "P@ssw0rd123";


### PR DESCRIPTION
## Summary
- expand RoleNames with additional roles
- seed new roles in DataSeeder
- add placeholder RegistriesController
- implement eight registry pages using Syncfusion grid
- enhance site stylesheet with utility classes
- extend main menu with registry links

## Testing
- `dotnet build GovServicesSolution.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68518fd6a39883238bddde8f4c708e99