### PR TITLE
Implement application results and revision mechanism

### DIFF
--- a/Client.Wasm/Client.Wasm/Components/RevisionModal.razor
+++ b/Client.Wasm/Client.Wasm/Components/RevisionModal.razor
@@ -1,0 +1,40 @@
+@using Syncfusion.Blazor.Popups
+@using Syncfusion.Blazor.Inputs
+@using Syncfusion.Blazor.DropDowns
+@using Client.Wasm.DTOs
+
+<SfDialog @ref="dlg" Width="450px" ShowCloseIcon="true" Header="Пересмотр" CssClass="rounded-xl shadow-lg glass-effect">
+    <EditForm Model="model" OnValidSubmit="HandleSubmit">
+        <DataAnnotationsValidator />
+        <div class="mb-3">
+            <SfDropDownList TValue="string" TItem="string" @bind-Value="model.Type" DataSource="reasons" Placeholder="Основание" CssClass="w-100" />
+        </div>
+        <SfTextBox @bind-Value="model.DocumentNumber" Placeholder="Номер документа" CssClass="w-100 mb-3" />
+        <SfTextBox @bind-Value="model.SedLink" Placeholder="Ссылка в СЭД" CssClass="w-100 mb-3" />
+        <div class="text-right">
+            <SfButton Type="Submit" CssClass="e-primary me-2">Сохранить</SfButton>
+            <SfButton CssClass="e-flat" OnClick="@( () => dlg.HideAsync() )">Отмена</SfButton>
+        </div>
+    </EditForm>
+</SfDialog>
+
+@code {
+    private SfDialog dlg;
+    private CreateApplicationRevisionDto model = new();
+    private string[] reasons = new[] { "Жалоба", "Протест прокуратуры", "Решение суда" };
+
+    public async Task Show(int applicationId)
+    {
+        model = new CreateApplicationRevisionDto { ApplicationId = applicationId };
+        await dlg.ShowAsync();
+    }
+
+    [Parameter] public EventCallback<CreateApplicationRevisionDto> OnSubmit { get; set; }
+
+    private async Task HandleSubmit()
+    {
+        if (OnSubmit.HasDelegate)
+            await OnSubmit.InvokeAsync(model);
+        await dlg.HideAsync();
+    }
+}

--- a/Client.Wasm/Client.Wasm/DTOs/ApplicationResultDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/ApplicationResultDto.cs
@@ -1,0 +1,12 @@
+namespace Client.Wasm.DTOs
+{
+    public class ApplicationResultDto
+    {
+        public int Id { get; set; }
+        public int ApplicationId { get; set; }
+        public int DocumentId { get; set; }
+        public string Type { get; set; }
+        public DateTime LinkedAt { get; set; }
+        public bool Automatic { get; set; }
+    }
+}

--- a/Client.Wasm/Client.Wasm/DTOs/ApplicationRevisionDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/ApplicationRevisionDto.cs
@@ -1,0 +1,12 @@
+namespace Client.Wasm.DTOs
+{
+    public class ApplicationRevisionDto
+    {
+        public int Id { get; set; }
+        public int ApplicationId { get; set; }
+        public string Type { get; set; }
+        public string DocumentNumber { get; set; }
+        public string SedLink { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/Client.Wasm/Client.Wasm/DTOs/CreateApplicationResultDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/CreateApplicationResultDto.cs
@@ -1,0 +1,10 @@
+namespace Client.Wasm.DTOs
+{
+    public class CreateApplicationResultDto
+    {
+        public int ApplicationId { get; set; }
+        public int DocumentId { get; set; }
+        public string Type { get; set; }
+        public bool Automatic { get; set; }
+    }
+}

--- a/Client.Wasm/Client.Wasm/DTOs/CreateApplicationRevisionDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/CreateApplicationRevisionDto.cs
@@ -1,0 +1,10 @@
+namespace Client.Wasm.DTOs
+{
+    public class CreateApplicationRevisionDto
+    {
+        public int ApplicationId { get; set; }
+        public string Type { get; set; }
+        public string DocumentNumber { get; set; }
+        public string SedLink { get; set; }
+    }
+}

--- a/Client.Wasm/Client.Wasm/Pages/ApplicationDetails.razor
+++ b/Client.Wasm/Client.Wasm/Pages/ApplicationDetails.razor
@@ -27,6 +27,51 @@
                 <p><b>Обновлена:</b> @app.UpdatedAt.ToShortDateString()</p>
             </SfCardContent>
         </SfCard>
+        <SfCard CssClass="mb-3">
+            <SfCardHeader>
+                <h3>Результаты</h3>
+            </SfCardHeader>
+            <SfCardContent>
+                <SfGrid TItem="ApplicationResultDto" DataSource="results" AllowPaging="true" Width="100%">
+                    <GridPageSettings PageSize="5" />
+                    <GridColumns>
+                        <GridColumn Field=@nameof(ApplicationResultDto.Type) HeaderText="Тип" Width="150" />
+                        <GridColumn Field=@nameof(ApplicationResultDto.LinkedAt) HeaderText="Дата" Format="g" Width="150" />
+                        <GridColumn HeaderText="Документ" Width="100">
+                            <Template>
+                                <a href="/documents/@(context as ApplicationResultDto).DocumentId" target="_blank">Открыть</a>
+                            </Template>
+                        </GridColumn>
+                    </GridColumns>
+                </SfGrid>
+            </SfCardContent>
+        </SfCard>
+
+        <SfCard CssClass="mb-3">
+            <SfCardHeader>
+                <div class="d-flex justify-content-between align-items-center">
+                    <h3 class="m-0">Пересмотры</h3>
+                    <SfButton CssClass="e-outline" OnClick="@(() => revisionModal.Show(app.Id))">Пересмотреть</SfButton>
+                </div>
+            </SfCardHeader>
+            <SfCardContent>
+                <SfGrid TItem="ApplicationRevisionDto" DataSource="revisions" AllowPaging="true" Width="100%">
+                    <GridPageSettings PageSize="5" />
+                    <GridColumns>
+                        <GridColumn Field=@nameof(ApplicationRevisionDto.Type) HeaderText="Тип" Width="150" />
+                        <GridColumn Field=@nameof(ApplicationRevisionDto.DocumentNumber) HeaderText="Номер" Width="150" />
+                        <GridColumn Field=@nameof(ApplicationRevisionDto.CreatedAt) HeaderText="Дата" Format="g" Width="150" />
+                        <GridColumn HeaderText="Документ" Width="120">
+                            <Template>
+                                <a href="@((context as ApplicationRevisionDto).SedLink)" target="_blank">Ссылка</a>
+                            </Template>
+                        </GridColumn>
+                    </GridColumns>
+                </SfGrid>
+            </SfCardContent>
+        </SfCard>
+
+        <RevisionModal @ref="revisionModal" OnSubmit="AddRevision" />
         <SfButton CssClass="e-flat" IconCss="e-icons e-arrow-left" OnClick="@( (MouseEventArgs e) => NavigationManager.NavigateTo("/applications") )">Назад</SfButton>
     }
 </div>
@@ -34,9 +79,21 @@
 @code {
     [Parameter] public int id { get; set; }
     ApplicationDto app;
+    List<ApplicationResultDto> results = new();
+    List<ApplicationRevisionDto> revisions = new();
+    RevisionModal revisionModal;
 
     protected override async Task OnParametersSetAsync()
     {
         app = await ApiClient.GetByIdAsync(id);
+        results = await ApiClient.GetResultsAsync(id);
+        revisions = await ApiClient.GetRevisionsAsync(id);
+    }
+
+    async Task AddRevision(CreateApplicationRevisionDto dto)
+    {
+        await ApiClient.AddRevisionAsync(dto);
+        revisions = await ApiClient.GetRevisionsAsync(id);
+        StateHasChanged();
     }
 }

--- a/Client.Wasm/Client.Wasm/Services/ApplicationApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/ApplicationApiClient.cs
@@ -12,6 +12,10 @@ public interface IApplicationApiClient
     Task DeleteAsync(int id);
     Task AdvanceAsync(int applicationId, object contextData);
     Task<List<ApplicationLogDto>> GetLogsAsync(int applicationId);
+    Task<List<ApplicationResultDto>> GetResultsAsync(int applicationId);
+    Task<ApplicationResultDto> AddResultAsync(CreateApplicationResultDto dto);
+    Task<List<ApplicationRevisionDto>> GetRevisionsAsync(int applicationId);
+    Task<ApplicationRevisionDto> AddRevisionAsync(CreateApplicationRevisionDto dto);
 }
 
 public class ApplicationApiClient : IApplicationApiClient
@@ -61,5 +65,29 @@ public class ApplicationApiClient : IApplicationApiClient
     public async Task<List<ApplicationLogDto>> GetLogsAsync(int applicationId)
     {
         return await _http.GetFromJsonAsync<List<ApplicationLogDto>>($"api/applications/{applicationId}/logs") ?? new();
+    }
+
+    public async Task<List<ApplicationResultDto>> GetResultsAsync(int applicationId)
+    {
+        return await _http.GetFromJsonAsync<List<ApplicationResultDto>>($"api/applications/{applicationId}/results") ?? new();
+    }
+
+    public async Task<ApplicationResultDto> AddResultAsync(CreateApplicationResultDto dto)
+    {
+        var res = await _http.PostAsJsonAsync($"api/applications/{dto.ApplicationId}/results", dto);
+        res.EnsureSuccessStatusCode();
+        return (await res.Content.ReadFromJsonAsync<ApplicationResultDto>())!;
+    }
+
+    public async Task<List<ApplicationRevisionDto>> GetRevisionsAsync(int applicationId)
+    {
+        return await _http.GetFromJsonAsync<List<ApplicationRevisionDto>>($"api/applications/{applicationId}/revisions") ?? new();
+    }
+
+    public async Task<ApplicationRevisionDto> AddRevisionAsync(CreateApplicationRevisionDto dto)
+    {
+        var res = await _http.PostAsJsonAsync($"api/applications/{dto.ApplicationId}/revisions", dto);
+        res.EnsureSuccessStatusCode();
+        return (await res.Content.ReadFromJsonAsync<ApplicationRevisionDto>())!;
     }
 }

--- a/Client.Wasm/Client.Wasm/_Imports.razor
+++ b/Client.Wasm/Client.Wasm/_Imports.razor
@@ -28,3 +28,4 @@
 @using Syncfusion.Blazor.Charts
 @using Syncfusion.Blazor.Lists
 @using System.ComponentModel.DataAnnotations
+@using Client.Wasm.Components

--- a/Server.Api/Server.Api/Controllers/ApplicationResultsController.cs
+++ b/Server.Api/Server.Api/Controllers/ApplicationResultsController.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+using GovServices.Server.DTOs;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/applications/{applicationId}/results")]
+public class ApplicationResultsController : ControllerBase
+{
+    private readonly IApplicationService _apps;
+
+    public ApplicationResultsController(IApplicationService apps)
+    {
+        _apps = apps;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<ApplicationResultDto>>> GetAll(int applicationId)
+    {
+        return await _apps.GetResultsAsync(applicationId);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<ApplicationResultDto>> Create(int applicationId, CreateApplicationResultDto dto)
+    {
+        if (applicationId != dto.ApplicationId) return BadRequest();
+        return await _apps.AddResultAsync(dto);
+    }
+}

--- a/Server.Api/Server.Api/Controllers/ApplicationRevisionsController.cs
+++ b/Server.Api/Server.Api/Controllers/ApplicationRevisionsController.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+using GovServices.Server.DTOs;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/applications/{applicationId}/revisions")]
+public class ApplicationRevisionsController : ControllerBase
+{
+    private readonly IApplicationService _apps;
+
+    public ApplicationRevisionsController(IApplicationService apps)
+    {
+        _apps = apps;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<ApplicationRevisionDto>>> GetAll(int applicationId)
+    {
+        return await _apps.GetRevisionsAsync(applicationId);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<ApplicationRevisionDto>> Create(int applicationId, CreateApplicationRevisionDto dto)
+    {
+        if (applicationId != dto.ApplicationId) return BadRequest();
+        return await _apps.AddRevisionAsync(dto);
+    }
+}

--- a/Server.Api/Server.Api/DTOs/ApplicationResultDto.cs
+++ b/Server.Api/Server.Api/DTOs/ApplicationResultDto.cs
@@ -1,0 +1,12 @@
+namespace GovServices.Server.DTOs
+{
+    public class ApplicationResultDto
+    {
+        public int Id { get; set; }
+        public int ApplicationId { get; set; }
+        public int DocumentId { get; set; }
+        public string Type { get; set; }
+        public DateTime LinkedAt { get; set; }
+        public bool Automatic { get; set; }
+    }
+}

--- a/Server.Api/Server.Api/DTOs/ApplicationRevisionDto.cs
+++ b/Server.Api/Server.Api/DTOs/ApplicationRevisionDto.cs
@@ -1,0 +1,12 @@
+namespace GovServices.Server.DTOs
+{
+    public class ApplicationRevisionDto
+    {
+        public int Id { get; set; }
+        public int ApplicationId { get; set; }
+        public string Type { get; set; }
+        public string DocumentNumber { get; set; }
+        public string SedLink { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/Server.Api/Server.Api/DTOs/CreateApplicationResultDto.cs
+++ b/Server.Api/Server.Api/DTOs/CreateApplicationResultDto.cs
@@ -1,0 +1,10 @@
+namespace GovServices.Server.DTOs
+{
+    public class CreateApplicationResultDto
+    {
+        public int ApplicationId { get; set; }
+        public int DocumentId { get; set; }
+        public string Type { get; set; }
+        public bool Automatic { get; set; }
+    }
+}

--- a/Server.Api/Server.Api/DTOs/CreateApplicationRevisionDto.cs
+++ b/Server.Api/Server.Api/DTOs/CreateApplicationRevisionDto.cs
@@ -1,0 +1,10 @@
+namespace GovServices.Server.DTOs
+{
+    public class CreateApplicationRevisionDto
+    {
+        public int ApplicationId { get; set; }
+        public string Type { get; set; }
+        public string DocumentNumber { get; set; }
+        public string SedLink { get; set; }
+    }
+}

--- a/Server.Api/Server.Api/Data/ApplicationDbContext.cs
+++ b/Server.Api/Server.Api/Data/ApplicationDbContext.cs
@@ -25,6 +25,8 @@ namespace GovServices.Server.Data
         public DbSet<Template> Templates { get; set; }
         public DbSet<RosreestrRequest> RosreestrRequests { get; set; }
         public DbSet<SedDocumentLog> SedDocumentLogs { get; set; }
+        public DbSet<ApplicationResult> ApplicationResults { get; set; }
+        public DbSet<ApplicationRevision> ApplicationRevisions { get; set; }
         public DbSet<AuditLog> AuditLogs { get; set; }
         public DbSet<PasswordChangeLog> PasswordChangeLogs { get; set; }
         public DbSet<Department> Departments { get; set; }

--- a/Server.Api/Server.Api/Entities/Application.cs
+++ b/Server.Api/Server.Api/Entities/Application.cs
@@ -19,5 +19,7 @@ namespace GovServices.Server.Entities
         public ICollection<OutgoingDocument> OutgoingDocuments { get; set; }
         public ICollection<RosreestrRequest> RosreestrRequests { get; set; }
         public ICollection<SedDocumentLog> SedLogs { get; set; }
+        public ICollection<ApplicationResult> Results { get; set; }
+        public ICollection<ApplicationRevision> Revisions { get; set; }
     }
 }

--- a/Server.Api/Server.Api/Entities/ApplicationResult.cs
+++ b/Server.Api/Server.Api/Entities/ApplicationResult.cs
@@ -1,0 +1,14 @@
+namespace GovServices.Server.Entities
+{
+    public class ApplicationResult
+    {
+        public int Id { get; set; }
+        public int ApplicationId { get; set; }
+        public Application Application { get; set; }
+        public int DocumentId { get; set; }
+        public Document Document { get; set; }
+        public string Type { get; set; }
+        public DateTime LinkedAt { get; set; }
+        public bool Automatic { get; set; }
+    }
+}

--- a/Server.Api/Server.Api/Entities/ApplicationRevision.cs
+++ b/Server.Api/Server.Api/Entities/ApplicationRevision.cs
@@ -1,0 +1,13 @@
+namespace GovServices.Server.Entities
+{
+    public class ApplicationRevision
+    {
+        public int Id { get; set; }
+        public int ApplicationId { get; set; }
+        public Application Application { get; set; }
+        public string Type { get; set; }
+        public string DocumentNumber { get; set; }
+        public string SedLink { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/Server.Api/Server.Api/Interfaces/IApplicationService.cs
+++ b/Server.Api/Server.Api/Interfaces/IApplicationService.cs
@@ -11,4 +11,8 @@ public interface IApplicationService
     Task DeleteAsync(int id);
     Task AdvanceAsync(int applicationId, object contextData);
     Task<List<ApplicationLogDto>> GetLogsAsync(int applicationId);
+    Task<List<ApplicationResultDto>> GetResultsAsync(int applicationId);
+    Task<ApplicationResultDto> AddResultAsync(CreateApplicationResultDto dto);
+    Task<List<ApplicationRevisionDto>> GetRevisionsAsync(int applicationId);
+    Task<ApplicationRevisionDto> AddRevisionAsync(CreateApplicationRevisionDto dto);
 }

--- a/Server.Api/Server.Api/Mappings/MappingProfile.cs
+++ b/Server.Api/Server.Api/Mappings/MappingProfile.cs
@@ -76,6 +76,12 @@ namespace GovServices.Server.Mappings
 
             CreateMap<CreateUserDto, ApplicationUser>();
             CreateMap<UpdateUserDto, ApplicationUser>();
+
+            CreateMap<ApplicationResult, ApplicationResultDto>().ReverseMap();
+            CreateMap<CreateApplicationResultDto, ApplicationResult>();
+
+            CreateMap<ApplicationRevision, ApplicationRevisionDto>().ReverseMap();
+            CreateMap<CreateApplicationRevisionDto, ApplicationRevision>();
         }
     }
 }

--- a/Server.Api/Server.Api/Services/ApplicationService.cs
+++ b/Server.Api/Server.Api/Services/ApplicationService.cs
@@ -7,11 +7,11 @@ using Microsoft.EntityFrameworkCore;
 
 namespace GovServices.Server.Services;
 
-public class ApplicationService : IApplicationService
-{
-    private readonly ApplicationDbContext _context;
-    private readonly IMapper _mapper;
-    private readonly IWorkflowService _workflowService;
+    public class ApplicationService : IApplicationService
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly IMapper _mapper;
+        private readonly IWorkflowService _workflowService;
 
     public ApplicationService(ApplicationDbContext context, IMapper mapper, IWorkflowService workflowService)
     {
@@ -142,5 +142,40 @@ public class ApplicationService : IApplicationService
             .OrderByDescending(l => l.Timestamp)
             .ToListAsync();
         return _mapper.Map<List<ApplicationLogDto>>(logs);
+    }
+
+    public async Task<List<ApplicationResultDto>> GetResultsAsync(int applicationId)
+    {
+        var results = await _context.ApplicationResults
+            .Where(r => r.ApplicationId == applicationId)
+            .Include(r => r.Document)
+            .ToListAsync();
+        return _mapper.Map<List<ApplicationResultDto>>(results);
+    }
+
+    public async Task<ApplicationResultDto> AddResultAsync(CreateApplicationResultDto dto)
+    {
+        var entity = _mapper.Map<ApplicationResult>(dto);
+        entity.LinkedAt = DateTime.UtcNow;
+        _context.ApplicationResults.Add(entity);
+        await _context.SaveChangesAsync();
+        return _mapper.Map<ApplicationResultDto>(entity);
+    }
+
+    public async Task<List<ApplicationRevisionDto>> GetRevisionsAsync(int applicationId)
+    {
+        var revisions = await _context.ApplicationRevisions
+            .Where(r => r.ApplicationId == applicationId)
+            .ToListAsync();
+        return _mapper.Map<List<ApplicationRevisionDto>>(revisions);
+    }
+
+    public async Task<ApplicationRevisionDto> AddRevisionAsync(CreateApplicationRevisionDto dto)
+    {
+        var entity = _mapper.Map<ApplicationRevision>(dto);
+        entity.CreatedAt = DateTime.UtcNow;
+        _context.ApplicationRevisions.Add(entity);
+        await _context.SaveChangesAsync();
+        return _mapper.Map<ApplicationRevisionDto>(entity);
     }
 }

--- a/Server.Api/Server.Api/Services/DocumentService.cs
+++ b/Server.Api/Server.Api/Services/DocumentService.cs
@@ -91,6 +91,19 @@ public class DocumentService : IDocumentService
 
         doc.Metadata = metadata;
 
+        if (applicationId > 0)
+        {
+            _context.ApplicationResults.Add(new ApplicationResult
+            {
+                ApplicationId = applicationId,
+                DocumentId = doc.Id,
+                Type = "Документ",
+                LinkedAt = DateTime.UtcNow,
+                Automatic = true
+            });
+            await _context.SaveChangesAsync();
+        }
+
         return _mapper.Map<DocumentDto>(doc);
     }
 


### PR DESCRIPTION
## Summary
- add entities for `ApplicationResult` and `ApplicationRevision`
- support new DTOs and AutoMapper mappings
- extend `ApplicationService` and API clients
- implement API controllers for results and revisions
- automatically link uploaded documents as results
- display results and revisions in application details page
- add revision modal component for manual review initiation

## Testing
- `dotnet build GovServicesSolution.sln`
- `dotnet test GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_6851abbb21b48323aa037fae5699c5b5