### PR TITLE
Add related applications tab

### DIFF
--- a/Client.Wasm/Client.Wasm/Components/RelatedApplicationsTabs.razor
+++ b/Client.Wasm/Client.Wasm/Components/RelatedApplicationsTabs.razor
@@ -1,0 +1,73 @@
+@using Syncfusion.Blazor.Navigations
+@using Syncfusion.Blazor.Grids
+@inject Services.IApplicationApiClient Api
+@inject NavigationManager Nav
+
+@if (appId != 0)
+{
+    <SfCard CssClass="rounded-xl shadow-lg glass-effect mb-4 p-6">
+        <SfTab>
+            <TabItems>
+                <TabItem HeaderText="Другие заявления заявителя">
+                    <ContentTemplate>
+                        <SfGrid DataSource="@byApplicant" AllowPaging="true" RowSelected="OnRowSelected" CssClass="e-bootstrap5">
+                            <GridPageSettings PageSize="5" />
+                            <GridColumns>
+                                <GridColumn Field=@nameof(ApplicationDto.Number) HeaderText="№" Width="120" />
+                                <GridColumn Field=@nameof(ApplicationDto.CreatedAt) HeaderText="Дата" Format="d" Width="150" />
+                                <GridColumn Field=@nameof(ApplicationDto.Status) HeaderText="Статус" Width="150" />
+                            </GridColumns>
+                        </SfGrid>
+                    </ContentTemplate>
+                </TabItem>
+                <TabItem HeaderText="Заявления с этим представителем">
+                    <ContentTemplate>
+                        <SfGrid DataSource="@byRepresentative" AllowPaging="true" RowSelected="OnRowSelected" CssClass="e-bootstrap5">
+                            <GridPageSettings PageSize="5" />
+                            <GridColumns>
+                                <GridColumn Field=@nameof(ApplicationDto.Number) HeaderText="№" Width="120" />
+                                <GridColumn Field=@nameof(ApplicationDto.CreatedAt) HeaderText="Дата" Format="d" Width="150" />
+                                <GridColumn Field=@nameof(ApplicationDto.Status) HeaderText="Статус" Width="150" />
+                            </GridColumns>
+                        </SfGrid>
+                    </ContentTemplate>
+                </TabItem>
+                <TabItem HeaderText="По пересечению координат">
+                    <ContentTemplate>
+                        <SfGrid DataSource="@byGeo" AllowPaging="true" RowSelected="OnRowSelected" CssClass="e-bootstrap5">
+                            <GridPageSettings PageSize="5" />
+                            <GridColumns>
+                                <GridColumn Field=@nameof(ApplicationDto.Number) HeaderText="№" Width="120" />
+                                <GridColumn Field=@nameof(ApplicationDto.CreatedAt) HeaderText="Дата" Format="d" Width="150" />
+                                <GridColumn Field=@nameof(ApplicationDto.Status) HeaderText="Статус" Width="150" />
+                            </GridColumns>
+                        </SfGrid>
+                    </ContentTemplate>
+                </TabItem>
+            </TabItems>
+        </SfTab>
+    </SfCard>
+}
+
+@code {
+    [Parameter] public int appId { get; set; }
+
+    List<ApplicationDto> byApplicant = new();
+    List<ApplicationDto> byRepresentative = new();
+    List<ApplicationDto> byGeo = new();
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (appId != 0)
+        {
+            byApplicant = await Api.GetRelatedByApplicantAsync(appId);
+            byRepresentative = await Api.GetRelatedByRepresentativeAsync(appId);
+            byGeo = await Api.GetRelatedByGeoAsync(appId);
+        }
+    }
+
+    void OnRowSelected(RowSelectEventArgs<ApplicationDto> args)
+    {
+        Nav.NavigateTo($"/applications/details/{args.Data.Id}");
+    }
+}

--- a/Client.Wasm/Client.Wasm/Pages/ApplicationDetails.razor
+++ b/Client.Wasm/Client.Wasm/Pages/ApplicationDetails.razor
@@ -67,9 +67,11 @@
                             </Template>
                         </GridColumn>
                     </GridColumns>
-                </SfGrid>
-            </SfCardContent>
-        </SfCard>
+        </SfGrid>
+    </SfCardContent>
+</SfCard>
+
+        <RelatedApplicationsTabs appId="@app.Id" />
 
         <RevisionModal @ref="revisionModal" OnSubmit="AddRevision" />
         <SfButton CssClass="e-flat" IconCss="e-icons e-arrow-left" OnClick="@( (MouseEventArgs e) => NavigationManager.NavigateTo("/applications") )">Назад</SfButton>

--- a/Client.Wasm/Client.Wasm/Services/ApplicationApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/ApplicationApiClient.cs
@@ -16,6 +16,10 @@ public interface IApplicationApiClient
     Task<ApplicationResultDto> AddResultAsync(CreateApplicationResultDto dto);
     Task<List<ApplicationRevisionDto>> GetRevisionsAsync(int applicationId);
     Task<ApplicationRevisionDto> AddRevisionAsync(CreateApplicationRevisionDto dto);
+
+    Task<List<ApplicationDto>> GetRelatedByApplicantAsync(int applicationId);
+    Task<List<ApplicationDto>> GetRelatedByRepresentativeAsync(int applicationId);
+    Task<List<ApplicationDto>> GetRelatedByGeoAsync(int applicationId);
 }
 
 public class ApplicationApiClient : IApplicationApiClient
@@ -89,5 +93,20 @@ public class ApplicationApiClient : IApplicationApiClient
         var res = await _http.PostAsJsonAsync($"api/applications/{dto.ApplicationId}/revisions", dto);
         res.EnsureSuccessStatusCode();
         return (await res.Content.ReadFromJsonAsync<ApplicationRevisionDto>())!;
+    }
+
+    public async Task<List<ApplicationDto>> GetRelatedByApplicantAsync(int applicationId)
+    {
+        return await _http.GetFromJsonAsync<List<ApplicationDto>>($"api/applications/{applicationId}/related/applicant") ?? new();
+    }
+
+    public async Task<List<ApplicationDto>> GetRelatedByRepresentativeAsync(int applicationId)
+    {
+        return await _http.GetFromJsonAsync<List<ApplicationDto>>($"api/applications/{applicationId}/related/representative") ?? new();
+    }
+
+    public async Task<List<ApplicationDto>> GetRelatedByGeoAsync(int applicationId)
+    {
+        return await _http.GetFromJsonAsync<List<ApplicationDto>>($"api/applications/{applicationId}/related/geo") ?? new();
     }
 }

--- a/Server.Api/Server.Api/Controllers/ApplicationsController.cs
+++ b/Server.Api/Server.Api/Controllers/ApplicationsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using GovServices.Server.Interfaces;
+using GovServices.Server.DTOs;
 
 namespace GovServices.Server.Controllers;
 
@@ -18,5 +19,33 @@ public class ApplicationsController : ControllerBase
     public IActionResult GetAll()
     {
         return Ok();
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<ApplicationDto>> GetById(int id)
+    {
+        var app = await _applications.GetByIdAsync(id);
+        return Ok(app);
+    }
+
+    [HttpGet("{id}/related/applicant")]
+    public async Task<ActionResult<List<ApplicationDto>>> GetRelatedByApplicant(int id)
+    {
+        var res = await _applications.GetByApplicantAsync(id);
+        return Ok(res);
+    }
+
+    [HttpGet("{id}/related/representative")]
+    public async Task<ActionResult<List<ApplicationDto>>> GetRelatedByRepresentative(int id)
+    {
+        var res = await _applications.GetByRepresentativeAsync(id);
+        return Ok(res);
+    }
+
+    [HttpGet("{id}/related/geo")]
+    public async Task<ActionResult<List<ApplicationDto>>> GetRelatedByGeo(int id)
+    {
+        var res = await _applications.GetByGeoIntersectionAsync(id);
+        return Ok(res);
     }
 }

--- a/Server.Api/Server.Api/Interfaces/IApplicationService.cs
+++ b/Server.Api/Server.Api/Interfaces/IApplicationService.cs
@@ -15,4 +15,8 @@ public interface IApplicationService
     Task<ApplicationResultDto> AddResultAsync(CreateApplicationResultDto dto);
     Task<List<ApplicationRevisionDto>> GetRevisionsAsync(int applicationId);
     Task<ApplicationRevisionDto> AddRevisionAsync(CreateApplicationRevisionDto dto);
+
+    Task<List<ApplicationDto>> GetByApplicantAsync(int applicationId);
+    Task<List<ApplicationDto>> GetByRepresentativeAsync(int applicationId);
+    Task<List<ApplicationDto>> GetByGeoIntersectionAsync(int applicationId);
 }

--- a/Server.Api/Server.Api/Services/ApplicationService.cs
+++ b/Server.Api/Server.Api/Services/ApplicationService.cs
@@ -178,4 +178,40 @@ namespace GovServices.Server.Services;
         await _context.SaveChangesAsync();
         return _mapper.Map<ApplicationRevisionDto>(entity);
     }
+
+    public async Task<List<ApplicationDto>> GetByApplicantAsync(int applicationId)
+    {
+        var apps = await _context.Applications
+            .Where(a => a.Id != applicationId)
+            .Include(a => a.Service)
+            .Include(a => a.CurrentStep)
+            .Include(a => a.AssignedTo)
+            .Take(10)
+            .ToListAsync();
+        return _mapper.Map<List<ApplicationDto>>(apps);
+    }
+
+    public async Task<List<ApplicationDto>> GetByRepresentativeAsync(int applicationId)
+    {
+        var apps = await _context.Applications
+            .Where(a => a.Id != applicationId)
+            .Include(a => a.Service)
+            .Include(a => a.CurrentStep)
+            .Include(a => a.AssignedTo)
+            .Take(10)
+            .ToListAsync();
+        return _mapper.Map<List<ApplicationDto>>(apps);
+    }
+
+    public async Task<List<ApplicationDto>> GetByGeoIntersectionAsync(int applicationId)
+    {
+        var apps = await _context.Applications
+            .Where(a => a.Id != applicationId)
+            .Include(a => a.Service)
+            .Include(a => a.CurrentStep)
+            .Include(a => a.AssignedTo)
+            .Take(10)
+            .ToListAsync();
+        return _mapper.Map<List<ApplicationDto>>(apps);
+    }
 }


### PR DESCRIPTION
## Summary
- add `RelatedApplicationsTabs` component with `SfTab` and `SfGrid`
- hook the component into ApplicationDetails page
- extend Application API client with related requests
- add server endpoints and stub service methods

## Testing
- `dotnet build GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_6851adb5a9b483238060423c1ba12118