### PR TITLE
Add basic unit tests

### DIFF
--- a/Client.Wasm.Tests/AuthServiceTests.cs
+++ b/Client.Wasm.Tests/AuthServiceTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components.Authorization;
+using Blazored.LocalStorage;
+using RichardSzalay.MockHttp;
+using Moq;
+using Xunit;
+using Client.Wasm.Services;
+using Client.Wasm.DTOs;
+
+namespace Client.Wasm.Tests;
+
+public class AuthServiceTests
+{
+    [Fact]
+    public async Task LoginAsync_ReturnsTrue_WhenResponseOk()
+    {
+        var handler = new MockHttpMessageHandler();
+        var dto = new LoginRequestDto { Email = "a@a.com", Password = "pass" };
+        var result = new AuthResultDto { Token = "jwt", Expiration = DateTime.UtcNow.AddHours(1) };
+        handler.When(HttpMethod.Post, "http://localhost/api/auth/login")
+            .Respond("application/json", JsonSerializer.Serialize(result));
+
+        var http = handler.ToHttpClient();
+        http.BaseAddress = new Uri("http://localhost");
+
+        var storageMock = new Mock<ILocalStorageService>();
+        storageMock.Setup(s => s.SetItemAsync<string>("authToken", It.IsAny<string>()))
+            .Returns(ValueTask.CompletedTask);
+
+        var provider = new CustomAuthStateProvider(storageMock.Object, http);
+        var service = new AuthService(http, provider);
+
+        var success = await service.LoginAsync(dto);
+
+        Assert.True(success);
+        storageMock.Verify(s => s.SetItemAsync<string>("authToken", "jwt"), Times.Once);
+    }
+
+    [Fact]
+    public async Task LoginAsync_ReturnsFalse_OnError()
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.When(HttpMethod.Post, "http://localhost/api/auth/login")
+            .Respond(HttpStatusCode.BadRequest);
+        var http = handler.ToHttpClient();
+        http.BaseAddress = new Uri("http://localhost");
+
+        var storageMock = new Mock<ILocalStorageService>();
+        var provider = new CustomAuthStateProvider(storageMock.Object, http);
+        var service = new AuthService(http, provider);
+
+        var success = await service.LoginAsync(new LoginRequestDto());
+
+        Assert.False(success);
+    }
+}

--- a/Client.Wasm.Tests/Client.Wasm.Tests.csproj
+++ b/Client.Wasm.Tests/Client.Wasm.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="bunit" Version="1.27.17" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Blazored.LocalStorage" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Client.Wasm/Client.Wasm/Client.Wasm.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Client.Wasm.Tests/LoginPageTests.razor.cs
+++ b/Client.Wasm.Tests/LoginPageTests.razor.cs
@@ -1,0 +1,74 @@
+using Bunit;
+using Bunit.TestDoubles;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using RichardSzalay.MockHttp;
+using System.Net.Http;
+using System.Text.Json;
+using Blazored.LocalStorage;
+using Syncfusion.Blazor;
+using Client.Wasm.Pages;
+using Client.Wasm.Services;
+using Client.Wasm.DTOs;
+
+namespace Client.Wasm.Tests;
+
+public class LoginPageTests : TestContext
+{
+    [Fact]
+    public void Login_ShowsError_WhenPasswordMissing()
+    {
+        var handler = new MockHttpMessageHandler();
+        var http = handler.ToHttpClient();
+        var storageMock = new Mock<ILocalStorageService>();
+        var authService = new AuthService(http, new CustomAuthStateProvider(storageMock.Object, http));
+        Services.AddSingleton(authService);
+        Services.AddSingleton<IAuthService>(authService);
+        Services.AddSingleton<AuthenticationStateProvider>(new TestAuthenticationStateProvider());
+        Services.AddSyncfusionBlazor();
+        Services.AddSingleton<FakeNavigationManager>();
+        Services.AddSingleton<NavigationManager>(sp => sp.GetRequiredService<FakeNavigationManager>());
+
+        var cut = RenderComponent<Login>();
+
+        cut.Find("form").Submit();
+
+        Assert.Contains("Password", cut.Markup, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Login_NavigatesHome_WhenSuccess()
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.When(HttpMethod.Post, "http://localhost/api/auth/login")
+            .Respond("application/json", JsonSerializer.Serialize(new AuthResultDto { Token = "jwt", Expiration = DateTime.UtcNow }));
+        var http = handler.ToHttpClient();
+        http.BaseAddress = new Uri("http://localhost");
+        var storageMock = new Mock<ILocalStorageService>();
+        var authService = new AuthService(http, new CustomAuthStateProvider(storageMock.Object, http));
+        Services.AddSingleton(authService);
+        Services.AddSingleton<IAuthService>(authService);
+        Services.AddSingleton<AuthenticationStateProvider>(new TestAuthenticationStateProvider());
+        Services.AddSyncfusionBlazor();
+        Services.AddSingleton<FakeNavigationManager>();
+        Services.AddSingleton<NavigationManager>(sp => sp.GetRequiredService<FakeNavigationManager>());
+
+        var nav = Services.GetRequiredService<FakeNavigationManager>();
+        var cut = RenderComponent<Login>();
+
+        cut.Find("input[placeholder='Эл. почта']").Change("a@a.com");
+        cut.Find("input[placeholder='Пароль']").Change("123456");
+        cut.Find("form").Submit();
+
+        Assert.Equal("http://localhost/", nav.Uri);
+    }
+}
+
+class TestAuthenticationStateProvider : AuthenticationStateProvider
+{
+    private readonly AuthenticationState _state = new(new System.Security.Claims.ClaimsPrincipal());
+    public override Task<AuthenticationState> GetAuthenticationStateAsync() => Task.FromResult(_state);
+}

--- a/GovServicesSolution.sln
+++ b/GovServicesSolution.sln
@@ -14,6 +14,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Client.Wasm", "Client.Wasm\
 		{C1A279CA-6FB4-45CA-A167-025E2CCE8C8F} = {C1A279CA-6FB4-45CA-A167-025E2CCE8C8F}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Server.Tests", "Server.Tests\Server.Tests.csproj", "{CFA8BC9B-6290-48F6-AB79-07B1789C9E60}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Client.Wasm.Tests", "Client.Wasm.Tests\Client.Wasm.Tests.csproj", "{8BAB554F-E44B-4A28-9D50-2A2454277772}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,6 +32,14 @@ Global
 		{562D94B3-15BD-4590-B948-C895D957AE1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{562D94B3-15BD-4590-B948-C895D957AE1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{562D94B3-15BD-4590-B948-C895D957AE1B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CFA8BC9B-6290-48F6-AB79-07B1789C9E60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CFA8BC9B-6290-48F6-AB79-07B1789C9E60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CFA8BC9B-6290-48F6-AB79-07B1789C9E60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CFA8BC9B-6290-48F6-AB79-07B1789C9E60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BAB554F-E44B-4A28-9D50-2A2454277772}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BAB554F-E44B-4A28-9D50-2A2454277772}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BAB554F-E44B-4A28-9D50-2A2454277772}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BAB554F-E44B-4A28-9D50-2A2454277772}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Server.Tests/AuthControllerTests.cs
+++ b/Server.Tests/AuthControllerTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+using GovServices.Server.Controllers;
+using GovServices.Server.Interfaces;
+using GovServices.Server.DTOs;
+
+namespace Server.Tests;
+
+public class AuthControllerTests
+{
+    [Fact]
+    public async Task Login_ReturnsToken_WhenCredentialsValid()
+    {
+        var dto = new LoginRequestDto { Email = "admin@test.com", Password = "pass" };
+        var authMock = new Mock<IAuthService>();
+        authMock.Setup(a => a.LoginAsync(dto)).ReturnsAsync(new AuthResultDto
+        {
+            Token = "token",
+            RefreshToken = "ref",
+            Expiration = DateTime.UtcNow.AddHours(1)
+        });
+        var controller = new AuthController(authMock.Object);
+
+        var result = await controller.Login(dto);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Login_ReturnsUnauthorized_WhenInvalid()
+    {
+        var dto = new LoginRequestDto { Email = "bad@test.com", Password = "bad" };
+        var authMock = new Mock<IAuthService>();
+        authMock.Setup(a => a.LoginAsync(dto)).ThrowsAsync(new UnauthorizedAccessException());
+        var controller = new AuthController(authMock.Object);
+
+        var result = await controller.Login(dto);
+
+        Assert.IsType<UnauthorizedObjectResult>(result);
+    }
+}

--- a/Server.Tests/RolesAndAccessTests.cs
+++ b/Server.Tests/RolesAndAccessTests.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+using GovServices.Server.Authorization;
+using GovServices.Server.Controllers;
+
+namespace Server.Tests;
+
+public class RolesAndAccessTests
+{
+    [Fact]
+    public void Clerical_Endpoint_Requires_Chancery_Role()
+    {
+        var method = typeof(RegistriesController).GetMethod("Clerical");
+        Assert.NotNull(method);
+        var attr = method!.GetCustomAttributes(typeof(AuthorizeAttribute), false)
+            .Cast<AuthorizeAttribute>()
+            .FirstOrDefault();
+        Assert.NotNull(attr);
+        Assert.Equal(RoleNames.Chancery, attr!.Roles);
+    }
+}

--- a/Server.Tests/Server.Tests.csproj
+++ b/Server.Tests/Server.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Server.Api/Server.Api/Server.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Server.Tests/ZayavlenieControllerTests.cs
+++ b/Server.Tests/ZayavlenieControllerTests.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+using GovServices.Server.Controllers;
+using GovServices.Server.Interfaces;
+using GovServices.Server.DTOs;
+
+namespace Server.Tests;
+
+public class ZayavlenieControllerTests
+{
+    [Fact]
+    public async Task GetByApplicant_ReturnsOk()
+    {
+        var serviceMock = new Mock<IApplicationService>();
+        serviceMock.Setup(s => s.GetByApplicantAsync(1)).ReturnsAsync(new List<ApplicationDto>());
+        var controller = new ApplicationsController(serviceMock.Object);
+
+        var result = await controller.GetRelatedByApplicant(1);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.IsType<List<ApplicationDto>>(ok.Value);
+    }
+
+    [Fact]
+    public async Task GetByRepresentative_ReturnsOk()
+    {
+        var serviceMock = new Mock<IApplicationService>();
+        serviceMock.Setup(s => s.GetByRepresentativeAsync(2)).ReturnsAsync(new List<ApplicationDto>());
+        var controller = new ApplicationsController(serviceMock.Object);
+
+        var result = await controller.GetRelatedByRepresentative(2);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.IsType<List<ApplicationDto>>(ok.Value);
+    }
+
+    [Fact]
+    public async Task AttachResult_ReturnsCreatedResult()
+    {
+        var dto = new CreateApplicationResultDto { ApplicationId = 5 };
+        var serviceMock = new Mock<IApplicationService>();
+        serviceMock.Setup(s => s.AddResultAsync(dto)).ReturnsAsync(new ApplicationResultDto { ApplicationId = 5 });
+        var controller = new ApplicationResultsController(serviceMock.Object);
+
+        var result = await controller.Create(5, dto);
+
+        var ok = Assert.IsType<ApplicationResultDto>(result.Value);
+        Assert.Equal(5, ok.ApplicationId);
+    }
+}


### PR DESCRIPTION
## Summary
- add server-side unit tests for controllers and role attributes
- add bUnit tests for client login flow
- add AuthService tests with mocked HTTP
- wire test projects into solution

## Testing
- `dotnet test Client.Wasm.Tests/Client.Wasm.Tests.csproj`
- `dotnet test Server.Tests/Server.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6851b0318ce88323a2ba7ad34a03df50