### PR TITLE
Add token-based integration module

### DIFF
--- a/Server.Api/Server.Api/DTOs/AttachmentDto.cs
+++ b/Server.Api/Server.Api/DTOs/AttachmentDto.cs
@@ -1,0 +1,7 @@
+namespace GovServices.Server.DTOs;
+
+public class AttachmentDto
+{
+    public string FileName { get; set; } = string.Empty;
+    public string ContentBase64 { get; set; } = string.Empty;
+}

--- a/Server.Api/Server.Api/DTOs/RosreestrRequestDto.cs
+++ b/Server.Api/Server.Api/DTOs/RosreestrRequestDto.cs
@@ -1,11 +1,11 @@
-namespace GovServices.Server.DTOs
+namespace GovServices.Server.DTOs;
+
+public class RosreestrRequestDto
 {
-    public class RosreestrRequestDto
-    {
-        public int Id { get; set; }
-        public int ApplicationId { get; set; }
-        public string RequestId { get; set; }
-        public string Status { get; set; }
-        public string ResponseData { get; set; }
-    }
+    public int Id { get; set; }
+    public int ApplicationId { get; set; }
+    public string RequestId { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+    public string ResponseData { get; set; } = string.Empty;
+    public List<AttachmentDto>? Attachments { get; set; }
 }

--- a/Server.Api/Server.Api/DTOs/ZagsRequestDto.cs
+++ b/Server.Api/Server.Api/DTOs/ZagsRequestDto.cs
@@ -1,11 +1,11 @@
-namespace GovServices.Server.DTOs
+namespace GovServices.Server.DTOs;
+
+public class ZagsRequestDto
 {
-    public class ZagsRequestDto
-    {
-        public int Id { get; set; }
-        public int ApplicationId { get; set; }
-        public string RequestId { get; set; }
-        public string Status { get; set; }
-        public string ResponseXml { get; set; }
-    }
+    public int Id { get; set; }
+    public int ApplicationId { get; set; }
+    public string RequestId { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+    public string ResponseXml { get; set; } = string.Empty;
+    public List<AttachmentDto>? Attachments { get; set; }
 }

--- a/Server.Api/Server.Api/DTOs/ZagsStatusApiDto.cs
+++ b/Server.Api/Server.Api/DTOs/ZagsStatusApiDto.cs
@@ -1,0 +1,16 @@
+namespace GovServices.Server.DTOs;
+
+public class ZagsStatusApiDto
+{
+    public string ResponseId { get; set; } = string.Empty;
+    public int State { get; set; }
+    public string StatusCode { get; set; } = string.Empty;
+    public string StatusMessage { get; set; } = string.Empty;
+    public DataDto Data { get; set; } = new();
+
+    public class DataDto
+    {
+        public string ResponceXml { get; set; } = string.Empty;
+        public List<AttachmentDto> Attachments { get; set; } = new();
+    }
+}

--- a/Server.Api/Server.Api/Data/ApplicationDbContext.cs
+++ b/Server.Api/Server.Api/Data/ApplicationDbContext.cs
@@ -25,6 +25,8 @@ namespace GovServices.Server.Data
         public DbSet<Template> Templates { get; set; }
         public DbSet<RosreestrRequest> RosreestrRequests { get; set; }
         public DbSet<ZagsRequest> ZagsRequests { get; set; }
+        public DbSet<ZagsRequestAttachment> ZagsRequestAttachments { get; set; }
+        public DbSet<RosreestrRequestAttachment> RosreestrRequestAttachments { get; set; }
         public DbSet<SedDocumentLog> SedDocumentLogs { get; set; }
         public DbSet<ApplicationResult> ApplicationResults { get; set; }
         public DbSet<ApplicationRevision> ApplicationRevisions { get; set; }

--- a/Server.Api/Server.Api/Entities/RosreestrRequest.cs
+++ b/Server.Api/Server.Api/Entities/RosreestrRequest.cs
@@ -1,13 +1,13 @@
-namespace GovServices.Server.Entities
+namespace GovServices.Server.Entities;
+
+public class RosreestrRequest
 {
-    public class RosreestrRequest
-    {
-        public int Id { get; set; }
-        public int ApplicationId { get; set; }
-        public Application Application { get; set; }
-        public string RequestId { get; set; }
-        public string Status { get; set; }
-        public string ResponseData { get; set; }
-        public DateTime CreatedAt { get; set; }
-    }
+    public int Id { get; set; }
+    public int ApplicationId { get; set; }
+    public Application Application { get; set; }
+    public string RequestId { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+    public string ResponseData { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public ICollection<RosreestrRequestAttachment> Attachments { get; set; } = new List<RosreestrRequestAttachment>();
 }

--- a/Server.Api/Server.Api/Entities/RosreestrRequestAttachment.cs
+++ b/Server.Api/Server.Api/Entities/RosreestrRequestAttachment.cs
@@ -1,0 +1,10 @@
+namespace GovServices.Server.Entities;
+
+public class RosreestrRequestAttachment
+{
+    public int Id { get; set; }
+    public int RosreestrRequestId { get; set; }
+    public RosreestrRequest RosreestrRequest { get; set; }
+    public string FileName { get; set; } = string.Empty;
+    public byte[] Content { get; set; } = Array.Empty<byte>();
+}

--- a/Server.Api/Server.Api/Entities/ZagsRequest.cs
+++ b/Server.Api/Server.Api/Entities/ZagsRequest.cs
@@ -1,13 +1,13 @@
-namespace GovServices.Server.Entities
+namespace GovServices.Server.Entities;
+
+public class ZagsRequest
 {
-    public class ZagsRequest
-    {
-        public int Id { get; set; }
-        public int ApplicationId { get; set; }
-        public Application Application { get; set; }
-        public string RequestId { get; set; } = string.Empty;
-        public string Status { get; set; } = string.Empty;
-        public string ResponseXml { get; set; } = string.Empty;
-        public DateTime CreatedAt { get; set; }
-    }
+    public int Id { get; set; }
+    public int ApplicationId { get; set; }
+    public Application Application { get; set; }
+    public string RequestId { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+    public string ResponseXml { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public ICollection<ZagsRequestAttachment> Attachments { get; set; } = new List<ZagsRequestAttachment>();
 }

--- a/Server.Api/Server.Api/Entities/ZagsRequestAttachment.cs
+++ b/Server.Api/Server.Api/Entities/ZagsRequestAttachment.cs
@@ -1,0 +1,10 @@
+namespace GovServices.Server.Entities;
+
+public class ZagsRequestAttachment
+{
+    public int Id { get; set; }
+    public int ZagsRequestId { get; set; }
+    public ZagsRequest ZagsRequest { get; set; }
+    public string FileName { get; set; } = string.Empty;
+    public byte[] Content { get; set; } = Array.Empty<byte>();
+}

--- a/Server.Api/Server.Api/Interfaces/IIntegrationService.cs
+++ b/Server.Api/Server.Api/Interfaces/IIntegrationService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace GovServices.Server.Interfaces;
+
+public interface IIntegrationService<TCreateDto, TResponseDto>
+{
+    Task<TResponseDto> SendRequestAsync(TCreateDto dto);
+    Task<TResponseDto> GetStatusAsync(string requestId);
+}

--- a/Server.Api/Server.Api/Interfaces/IRosreestrIntegrationService.cs
+++ b/Server.Api/Server.Api/Interfaces/IRosreestrIntegrationService.cs
@@ -2,8 +2,6 @@ using GovServices.Server.DTOs;
 
 namespace GovServices.Server.Interfaces;
 
-public interface IRosreestrIntegrationService
+public interface IRosreestrIntegrationService : IIntegrationService<CreateRosreestrRequestDto, RosreestrRequestDto>
 {
-    Task<RosreestrRequestDto> SendRequestAsync(int applicationId);
-    Task<RosreestrRequestDto> GetStatusAsync(string requestId);
 }

--- a/Server.Api/Server.Api/Interfaces/IZagsIntegrationService.cs
+++ b/Server.Api/Server.Api/Interfaces/IZagsIntegrationService.cs
@@ -2,8 +2,6 @@ using GovServices.Server.DTOs;
 
 namespace GovServices.Server.Interfaces;
 
-public interface IZagsIntegrationService
+public interface IZagsIntegrationService : IIntegrationService<CreateZagsRequestDto, ZagsRequestDto>
 {
-    Task<ZagsRequestDto> SendRequestAsync(CreateZagsRequestDto dto);
-    Task<ZagsRequestDto> GetStatusAsync(string requestId);
 }

--- a/Server.Api/Server.Api/Mappings/MappingProfile.cs
+++ b/Server.Api/Server.Api/Mappings/MappingProfile.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using GovServices.Server.Entities;
 using GovServices.Server.DTOs;
+using System;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
 using System.Linq;
@@ -56,7 +57,24 @@ namespace GovServices.Server.Mappings
 
             CreateMap<CreateOutgoingDocumentDto, OutgoingDocument>();
 
-            CreateMap<RosreestrRequest, RosreestrRequestDto>().ReverseMap();
+            CreateMap<ZagsRequest, ZagsRequestDto>()
+                .ForMember(d => d.Attachments, o => o.MapFrom(s => s.Attachments.Select(a => new AttachmentDto
+                {
+                    FileName = a.FileName,
+                    ContentBase64 = Convert.ToBase64String(a.Content)
+                }).ToList()))
+                .ReverseMap()
+                .ForMember(d => d.Attachments, o => o.Ignore());
+            CreateMap<CreateZagsRequestDto, ZagsRequest>();
+
+            CreateMap<RosreestrRequest, RosreestrRequestDto>()
+                .ForMember(d => d.Attachments, o => o.MapFrom(s => s.Attachments.Select(a => new AttachmentDto
+                {
+                    FileName = a.FileName,
+                    ContentBase64 = Convert.ToBase64String(a.Content)
+                }).ToList()))
+                .ReverseMap()
+                .ForMember(d => d.Attachments, o => o.Ignore());
             CreateMap<CreateRosreestrRequestDto, RosreestrRequest>();
             CreateMap<SedDocumentLog, SedDocumentLogDto>().ReverseMap();
             CreateMap<Service, ServiceDto>().ReverseMap();

--- a/Server.Api/Server.Api/Services/Integrations/Base/IntegrationServiceBase.cs
+++ b/Server.Api/Server.Api/Services/Integrations/Base/IntegrationServiceBase.cs
@@ -1,0 +1,97 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using GovServices.Server.Data;
+using GovServices.Server.DTOs;
+
+namespace GovServices.Server.Services.Integrations.Base;
+
+public abstract class IntegrationServiceBase<TCreateDto, TResponseDto>
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    protected readonly ApplicationDbContext Context;
+    private readonly ILogger _logger;
+    private readonly IConfiguration _configuration;
+
+    private string? _token;
+
+    protected IntegrationServiceBase(
+        IHttpClientFactory httpClientFactory,
+        ApplicationDbContext context,
+        IConfiguration configuration,
+        ILogger logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        Context = context;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    protected abstract string ServiceName { get; }
+    protected abstract string ApiUrl { get; }
+    protected abstract string Login { get; }
+    protected abstract string Password { get; }
+
+    public abstract Task<TResponseDto> SendRequestAsync(TCreateDto dto);
+    public abstract Task<TResponseDto> GetStatusAsync(string requestId);
+
+    private async Task<string> GetTokenAsync(bool force = false)
+    {
+        if (!force && !string.IsNullOrWhiteSpace(_token))
+            return _token!;
+
+        var client = _httpClientFactory.CreateClient();
+        var body = new { Login, Password };
+        _logger.LogInformation("[{Service}] Requesting token", ServiceName);
+        var response = await client.PostAsJsonAsync($"{ApiUrl}/Token", body);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("[{Service}] Token request failed: {Status}", ServiceName, response.StatusCode);
+            response.EnsureSuccessStatusCode();
+        }
+
+        var tokenDto = await response.Content.ReadFromJsonAsync<TokenDto>() ??
+                       throw new InvalidOperationException("Invalid token response");
+        _token = tokenDto.Token;
+        return _token!;
+    }
+
+    protected async Task<HttpClient> CreateAuthorizedClientAsync(bool refresh = false)
+    {
+        var token = await GetTokenAsync(refresh);
+        var client = _httpClientFactory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return client;
+    }
+
+    protected async Task<TResponse> SendWithAuthAsync<TResponse, TRequest>(string url, HttpMethod method, TRequest body)
+    {
+        var client = await CreateAuthorizedClientAsync();
+        HttpResponseMessage response;
+        var request = new HttpRequestMessage(method, url);
+        if (body != null)
+            request.Content = JsonContent.Create(body);
+        _logger.LogInformation("[{Service}] {Method} {Url}", ServiceName, method, url);
+        response = await client.SendAsync(request);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+        {
+            client = await CreateAuthorizedClientAsync(true);
+            request = new HttpRequestMessage(method, url);
+            if (body != null)
+                request.Content = JsonContent.Create(body);
+            _logger.LogInformation("[{Service}] Retrying after token refresh", ServiceName);
+            response = await client.SendAsync(request);
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("[{Service}] Error response {Status}", ServiceName, response.StatusCode);
+        }
+
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TResponse>() ?? throw new InvalidOperationException("Invalid response");
+    }
+
+    private record TokenDto(string Token);
+}

--- a/Server.Api/Server.Api/Services/Integrations/RosreestrIntegrationService.cs
+++ b/Server.Api/Server.Api/Services/Integrations/RosreestrIntegrationService.cs
@@ -1,84 +1,72 @@
+using System;
 using System.Net.Http.Json;
-using System.Text.Json;
 using GovServices.Server.Data;
 using GovServices.Server.DTOs;
 using GovServices.Server.Entities;
 using GovServices.Server.Interfaces;
+using GovServices.Server.Services.Integrations.Base;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace GovServices.Server.Services.Integrations;
 
-public class RosreestrIntegrationService : IRosreestrIntegrationService
+public class RosreestrIntegrationService : IntegrationServiceBase<CreateRosreestrRequestDto, RosreestrRequestDto>, IRosreestrIntegrationService
 {
-    private readonly IHttpClientFactory _httpClientFactory;
-    private readonly ApplicationDbContext _context;
+    private readonly ILogger<RosreestrIntegrationService> _logger;
     private readonly IConfiguration _configuration;
 
-    private string ApiUrl => _configuration["Rosreestr:ApiUrl"] ?? string.Empty;
+    protected override string ServiceName => "Rosreestr";
+    protected override string ApiUrl => _configuration["Rosreestr:ApiUrl"] ?? string.Empty;
+    protected override string Login => _configuration["Rosreestr:Login"] ?? string.Empty;
+    protected override string Password => _configuration["Rosreestr:Password"] ?? string.Empty;
 
     public RosreestrIntegrationService(
         IHttpClientFactory httpClientFactory,
         ApplicationDbContext context,
-        IConfiguration configuration)
+        IConfiguration configuration,
+        ILogger<RosreestrIntegrationService> logger)
+        : base(httpClientFactory, context, configuration, logger)
     {
-        _httpClientFactory = httpClientFactory;
-        _context = context;
+        _logger = logger;
         _configuration = configuration;
     }
 
-    public async Task<RosreestrRequestDto> SendRequestAsync(int applicationId)
+    public override async Task<RosreestrRequestDto> SendRequestAsync(CreateRosreestrRequestDto dto)
     {
-        var application = await _context.Set<Application>()
-            .FirstOrDefaultAsync(a => a.Id == applicationId);
-        if (application == null)
-            throw new InvalidOperationException($"Application {applicationId} not found");
+        var app = await Context.Applications.FirstOrDefaultAsync(a => a.Id == dto.ApplicationId)
+            ?? throw new InvalidOperationException($"Application {dto.ApplicationId} not found");
 
-        var body = new { application.Id, application.Number };
-
-        var client = _httpClientFactory.CreateClient();
-        var response = await client.PostAsJsonAsync($"{ApiUrl}/sendRequest", body);
-        response.EnsureSuccessStatusCode();
-
-        var stream = await response.Content.ReadAsStreamAsync();
-        var dto = await JsonSerializer.DeserializeAsync<RosreestrRequestDto>(stream) ??
-                  throw new InvalidOperationException("Invalid response from Rosreestr");
+        var body = new { app.Id, app.Number };
+        var result = await SendWithAuthAsync<RosreestrRequestDto, object>($"{ApiUrl}/api/request", HttpMethod.Post, body);
 
         var entity = new RosreestrRequest
         {
-            ApplicationId = applicationId,
-            RequestId = dto.RequestId,
-            Status = dto.Status,
-            ResponseData = dto.ResponseData,
+            ApplicationId = dto.ApplicationId,
+            RequestId = result.RequestId,
+            Status = result.Status,
+            ResponseData = result.ResponseData,
             CreatedAt = DateTime.UtcNow
         };
-
-        _context.Set<RosreestrRequest>().Add(entity);
-        await _context.SaveChangesAsync();
-
-        dto.Id = entity.Id;
-        return dto;
+        Context.Set<RosreestrRequest>().Add(entity);
+        await Context.SaveChangesAsync();
+        result.Id = entity.Id;
+        return result;
     }
 
-    public async Task<RosreestrRequestDto> GetStatusAsync(string requestId)
+    public override async Task<RosreestrRequestDto> GetStatusAsync(string requestId)
     {
-        var client = _httpClientFactory.CreateClient();
-        var response = await client.GetAsync($"{ApiUrl}/status/{requestId}");
-        response.EnsureSuccessStatusCode();
+        var dto = await SendWithAuthAsync<RosreestrRequestDto, object?>($"{ApiUrl}/api/status/{requestId}", HttpMethod.Get, null);
 
-        var stream = await response.Content.ReadAsStreamAsync();
-        var dto = await JsonSerializer.DeserializeAsync<RosreestrRequestDto>(stream) ??
-                  throw new InvalidOperationException("Invalid response from Rosreestr");
-
-        var entity = await _context.Set<RosreestrRequest>()
+        var entity = await Context.Set<RosreestrRequest>()
+            .Include(r => r.Attachments)
             .FirstOrDefaultAsync(r => r.RequestId == requestId);
         if (entity != null)
         {
             entity.Status = dto.Status;
             entity.ResponseData = dto.ResponseData;
-            await _context.SaveChangesAsync();
+            await Context.SaveChangesAsync();
         }
 
         return dto;
     }
 }
-

--- a/Server.Api/Server.Api/Services/Integrations/ZagsIntegrationService.cs
+++ b/Server.Api/Server.Api/Services/Integrations/ZagsIntegrationService.cs
@@ -1,37 +1,39 @@
+using System;
 using System.Net.Http.Json;
 using GovServices.Server.Data;
 using GovServices.Server.DTOs;
 using GovServices.Server.Entities;
 using GovServices.Server.Interfaces;
+using GovServices.Server.Services.Integrations.Base;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace GovServices.Server.Services.Integrations;
 
-public class ZagsIntegrationService : IZagsIntegrationService
+public class ZagsIntegrationService : IntegrationServiceBase<CreateZagsRequestDto, ZagsRequestDto>, IZagsIntegrationService
 {
-    private readonly IHttpClientFactory _httpClientFactory;
-    private readonly ApplicationDbContext _context;
+    private readonly ILogger<ZagsIntegrationService> _logger;
     private readonly IConfiguration _configuration;
 
-    private string ApiUrl => _configuration["Zags:ApiUrl"] ?? string.Empty;
+    protected override string ServiceName => "ZAGS";
+    protected override string ApiUrl => _configuration["Zags:ApiUrl"] ?? string.Empty;
+    protected override string Login => _configuration["Zags:Login"] ?? string.Empty;
+    protected override string Password => _configuration["Zags:Password"] ?? string.Empty;
 
-    public ZagsIntegrationService(IHttpClientFactory httpClientFactory,
+    public ZagsIntegrationService(
+        IHttpClientFactory httpClientFactory,
         ApplicationDbContext context,
-        IConfiguration configuration)
+        IConfiguration configuration,
+        ILogger<ZagsIntegrationService> logger)
+        : base(httpClientFactory, context, configuration, logger)
     {
-        _httpClientFactory = httpClientFactory;
-        _context = context;
+        _logger = logger;
         _configuration = configuration;
     }
 
-    public async Task<ZagsRequestDto> SendRequestAsync(CreateZagsRequestDto dto)
+    public override async Task<ZagsRequestDto> SendRequestAsync(CreateZagsRequestDto dto)
     {
-        var client = _httpClientFactory.CreateClient();
-        var response = await client.PostAsJsonAsync($"{ApiUrl}/request", dto);
-        response.EnsureSuccessStatusCode();
-
-        var result = await response.Content.ReadFromJsonAsync<ZagsRequestDto>() ??
-                     throw new InvalidOperationException("Invalid response from ZAGS");
+        var result = await SendWithAuthAsync<ZagsRequestDto, CreateZagsRequestDto>($"{ApiUrl}/api/Zags/InformApi/CreateInformRequst", HttpMethod.Post, dto);
 
         var entity = new ZagsRequest
         {
@@ -41,32 +43,42 @@ public class ZagsIntegrationService : IZagsIntegrationService
             ResponseXml = result.ResponseXml,
             CreatedAt = DateTime.UtcNow
         };
-
-        _context.Set<ZagsRequest>().Add(entity);
-        await _context.SaveChangesAsync();
-
+        Context.Set<ZagsRequest>().Add(entity);
+        await Context.SaveChangesAsync();
         result.Id = entity.Id;
         return result;
     }
 
-    public async Task<ZagsRequestDto> GetStatusAsync(string requestId)
+    public override async Task<ZagsRequestDto> GetStatusAsync(string requestId)
     {
-        var client = _httpClientFactory.CreateClient();
-        var response = await client.GetAsync($"{ApiUrl}/status/{requestId}");
-        response.EnsureSuccessStatusCode();
+        var apiDto = await SendWithAuthAsync<ZagsStatusApiDto, object?>($"{ApiUrl}/api/Zags/StatusApi/GetStatus/{requestId}", HttpMethod.Get, null);
 
-        var dto = await response.Content.ReadFromJsonAsync<ZagsRequestDto>() ??
-                  throw new InvalidOperationException("Invalid response from ZAGS");
+        var dto = new ZagsRequestDto
+        {
+            RequestId = requestId,
+            Status = apiDto.StatusCode,
+            ResponseXml = apiDto.Data.ResponceXml,
+            Attachments = apiDto.Data.Attachments
+        };
 
-        var entity = await _context.Set<ZagsRequest>()
+        var entity = await Context.Set<ZagsRequest>()
+            .Include(r => r.Attachments)
             .FirstOrDefaultAsync(r => r.RequestId == requestId);
         if (entity != null)
         {
             entity.Status = dto.Status;
             entity.ResponseXml = dto.ResponseXml;
-            await _context.SaveChangesAsync();
+            entity.Attachments.Clear();
+            foreach (var att in dto.Attachments ?? new())
+            {
+                entity.Attachments.Add(new ZagsRequestAttachment
+                {
+                    FileName = att.FileName,
+                    Content = Convert.FromBase64String(att.ContentBase64)
+                });
+            }
+            await Context.SaveChangesAsync();
         }
-
         return dto;
     }
 }

--- a/Server.Tests/RosreestrIntegrationServiceTests.cs
+++ b/Server.Tests/RosreestrIntegrationServiceTests.cs
@@ -29,10 +29,16 @@ public class RosreestrIntegrationServiceTests
         });
         var client = new HttpClient(handler);
         var factory = new FakeHttpClientFactory(client);
-        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string,string>{{"Rosreestr:ApiUrl","http://test"}}).Build();
-        var service = new RosreestrIntegrationService(factory, context, config);
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string,string>
+        {
+            {"Rosreestr:ApiUrl","http://test"},
+            {"Rosreestr:Login","login"},
+            {"Rosreestr:Password","pass"}
+        }).Build();
+        var logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<RosreestrIntegrationService>.Instance;
+        var service = new RosreestrIntegrationService(factory, context, config, logger);
 
-        var result = await service.SendRequestAsync(1);
+        var result = await service.SendRequestAsync(new CreateRosreestrRequestDto { ApplicationId = 1 });
 
         Assert.Equal("r1", result.RequestId);
         Assert.Equal(1, await context.RosreestrRequests.CountAsync());

--- a/Server.Tests/Server.Tests.csproj
+++ b/Server.Tests/Server.Tests.csproj
@@ -20,7 +20,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
   </ItemGroup>
 

--- a/Server.Tests/ZagsIntegrationServiceTests.cs
+++ b/Server.Tests/ZagsIntegrationServiceTests.cs
@@ -29,8 +29,14 @@ public class ZagsIntegrationServiceTests
         });
         var client = new HttpClient(handler);
         var factory = new FakeHttpClientFactory(client);
-        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string,string>{{"Zags:ApiUrl","http://test"}}).Build();
-        var service = new ZagsIntegrationService(factory, context, config);
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string,string>
+        {
+            {"Zags:ApiUrl","http://test"},
+            {"Zags:Login","login"},
+            {"Zags:Password","pass"}
+        }).Build();
+        var logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<ZagsIntegrationService>.Instance;
+        var service = new ZagsIntegrationService(factory, context, config, logger);
 
         var dtoResult = await service.SendRequestAsync(new CreateZagsRequestDto { ApplicationId = 1 });
 


### PR DESCRIPTION
## Summary
- add integration base service with token auth
- extend ZAGS and Rosreestr DTOs with attachment support
- implement new ZAGS/Rosreestr services using token refresh
- store attachments in new entities
- adjust tests and add missing packages

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68527741d964832388bfb413873a145c