### PR TITLE
Implement Word template editing

### DIFF
--- a/Client.Wasm/Client.Wasm/Client.Wasm.csproj
+++ b/Client.Wasm/Client.Wasm/Client.Wasm.csproj
@@ -13,7 +13,17 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Syncfusion.Blazor" Version="24.1.41" />
+    <PackageReference Include="Syncfusion.Blazor.Buttons" Version="24.1.41" />
+    <PackageReference Include="Syncfusion.Blazor.Inputs" Version="24.1.41" />
+    <PackageReference Include="Syncfusion.Blazor.Grid" Version="24.1.41" />
+    <PackageReference Include="Syncfusion.Blazor.DropDowns" Version="24.1.41" />
+    <PackageReference Include="Syncfusion.Blazor.Navigations" Version="24.1.41" />
+    <PackageReference Include="Syncfusion.Blazor.Popups" Version="24.1.41" />
+    <PackageReference Include="Syncfusion.Blazor.Layouts" Version="24.1.41" />
+    <PackageReference Include="Syncfusion.Blazor.Charts" Version="24.1.41" />
+    <PackageReference Include="Syncfusion.Blazor.Lists" Version="24.1.41" />
+    <PackageReference Include="Syncfusion.Blazor.FileManager" Version="24.1.41" />
+    <PackageReference Include="Syncfusion.Blazor.WordProcessor" Version="24.1.41" />
     <PackageReference Include="Syncfusion.Blazor.Themes" Version="24.1.41" />
   </ItemGroup>
 

--- a/Client.Wasm/Client.Wasm/Components/DocumentResultViewer.razor
+++ b/Client.Wasm/Client.Wasm/Components/DocumentResultViewer.razor
@@ -1,0 +1,33 @@
+@using Syncfusion.Blazor.DocumentEditor
+@inject IJSRuntime JS
+
+<SfDialog @ref="dialog" Width="900px" ShowCloseIcon="true" Header="Результат">
+    <SfDocumentEditorContainer @ref="container" Height="500px" EnableToolbar="true">
+        <DocumentEditorSettings EnableSpellCheck="false" EnableReadOnly="true" EnableSfdtExport="true"></DocumentEditorSettings>
+    </SfDocumentEditorContainer>
+    <div class="text-right mt-3">
+        <SfButton CssClass="e-flat me-2" OnClick="DownloadWord">Скачать Word</SfButton>
+        <SfButton CssClass="e-flat" OnClick="Close">Закрыть</SfButton>
+    </div>
+</SfDialog>
+
+@code {
+    SfDialog dialog;
+    SfDocumentEditorContainer container;
+    string content = string.Empty;
+
+    public async Task Show(string sfdt)
+    {
+        content = sfdt;
+        await container.DocumentEditor.OpenAsync(content);
+        await dialog.ShowAsync();
+    }
+
+    async Task DownloadWord()
+    {
+        var data = await container.DocumentEditor.SaveAsBlobAsync(FormatType.Docx);
+        await JS.InvokeVoidAsync("saveAsFile", "document.docx", data);
+    }
+
+    void Close() => dialog.HideAsync();
+}

--- a/Client.Wasm/Client.Wasm/Components/DocumentTemplateEditor.razor
+++ b/Client.Wasm/Client.Wasm/Components/DocumentTemplateEditor.razor
@@ -1,0 +1,76 @@
+@using Syncfusion.Blazor.DocumentEditor
+@inject IDocumentTemplateService TemplateService
+
+<SfDialog @ref="dialog" Width="900px" ShowCloseIcon="true" Header="Редактор шаблона">
+    <div class="row">
+        <div class="col-9">
+            <SfDocumentEditorContainer @ref="container" Height="500px" EnableToolbar="true">
+                <DocumentEditorSettings EnableSpellCheck="false" EnableSfdtExport="true"></DocumentEditorSettings>
+            </SfDocumentEditorContainer>
+        </div>
+        <div class="col-3">
+            <h5>Поля</h5>
+            <ul class="list-unstyled">
+                @foreach (var f in Fields)
+                {
+                    <li class="mb-2"><SfButton CssClass="e-flat" OnClick="() => InsertField(f)">@f</SfButton></li>
+                }
+            </ul>
+        </div>
+    </div>
+    <div class="text-right mt-3">
+        <SfButton CssClass="e-primary me-2" OnClick="Save">Сохранить</SfButton>
+        <SfButton CssClass="e-flat" OnClick="Close">Отмена</SfButton>
+    </div>
+</SfDialog>
+
+@code {
+    SfDialog dialog;
+    SfDocumentEditorContainer container;
+    TemplateDto model = new();
+    bool isNew;
+
+    List<string> Fields = new() { "ФИО_Заявителя", "Дата_Регистрации", "Услуга", "ФИО_Представителя", "Тип_Результата" };
+
+    public async Task Show(int? id = null)
+    {
+        if (id.HasValue)
+        {
+            model = await TemplateService.GetByIdAsync(id.Value) ?? new TemplateDto();
+            isNew = false;
+            await container.DocumentEditor.OpenAsync(model.Content ?? "{}");
+        }
+        else
+        {
+            model = new TemplateDto { Type = "Word" };
+            isNew = true;
+            await container.DocumentEditor.OpenBlankAsync();
+        }
+        await dialog.ShowAsync();
+    }
+
+    async Task InsertField(string field)
+    {
+        await container.DocumentEditor.Editor.InsertTextAsync($"{{{{{field}}}}}");
+    }
+
+    async Task Save()
+    {
+        var content = await container.DocumentEditor.SaveAsBlobAsync(FormatType.Sfdt);
+        if (isNew)
+        {
+            await TemplateService.CreateAsync(new CreateTemplateDto { Name = model.Name, Type = "Word", Content = content });
+        }
+        else
+        {
+            await TemplateService.UpdateAsync(model.Id, new UpdateTemplateDto { Name = model.Name, Type = "Word", Content = content });
+        }
+        await dialog.HideAsync();
+        if (OnSaved.HasDelegate)
+            await OnSaved.InvokeAsync();
+    }
+
+    void Close() => dialog.HideAsync();
+
+    [Parameter] public EventCallback OnSaved { get; set; }
+}

--- a/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
+++ b/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
@@ -67,6 +67,7 @@
         new MenuItem { Text = "Applications", Url = "/applications" },
         new MenuItem { Text = "Documents", Url = "/documents/0" },
         new MenuItem { Text = "Templates", Url = "/templates" },
+        new MenuItem { Text = "Document Templates", Url = "/document-templates" },
         new MenuItem { Text = "Users", Url = "/users" },
         new MenuItem { Text = "Permission Groups", Url = "/permission-groups" },
         new MenuItem { Text = "Актуальные заявления", Url = "/registry/applications" },

--- a/Client.Wasm/Client.Wasm/Pages/DocumentTemplates.razor
+++ b/Client.Wasm/Client.Wasm/Pages/DocumentTemplates.razor
@@ -1,0 +1,47 @@
+@attribute [Authorize(Roles="Administrator")]
+@page "/document-templates"
+@inject IDocumentTemplateService TemplateService
+@inject IJSRuntime JsRuntime
+
+<div class="container p-4">
+    <SfCard CssClass="mb-4">
+        <CardHeader>
+            <h1>Шаблоны документов</h1>
+        </CardHeader>
+        <CardContent>
+            <SfButton CssClass="e-primary mb-3" IconCss="e-icons e-add" OnClick="@( _ => editor.Show())">Новый шаблон</SfButton>
+            <SfGrid TItem="TemplateDto" DataSource="items" AllowPaging="true" Width="100%" CssClass="e-bootstrap5">
+                <GridColumns>
+                    <GridColumn Field=@nameof(TemplateDto.Id) HeaderText="ID" Width="70" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
+                    <GridColumn Field=@nameof(TemplateDto.Name) HeaderText="Название" Width="200" />
+                    <GridColumn HeaderText="Действия" TextAlign="TextAlign.Center" Width="150">
+                        <Template>
+                            <SfButton CssClass="e-flat" IconCss="e-icons e-edit" OnClick="@( (MouseEventArgs e) => editor.Show((context as TemplateDto).Id) )" />
+                            <SfButton CssClass="e-flat e-danger" IconCss="e-icons e-delete" OnClick="@( (MouseEventArgs e) => Delete((context as TemplateDto).Id) )" />
+                        </Template>
+                    </GridColumn>
+                </GridColumns>
+            </SfGrid>
+        </CardContent>
+    </SfCard>
+
+    <DocumentTemplateEditor @ref="editor" OnSaved="Load" />
+</div>
+
+@code {
+    List<TemplateDto> items = new();
+    DocumentTemplateEditor editor;
+
+    protected override async Task OnInitializedAsync() => await Load();
+
+    async Task Load() => items = await TemplateService.GetAllAsync();
+
+    async Task Delete(int id)
+    {
+        if (await JsRuntime.InvokeAsync<bool>("confirm", $"Удалить шаблон {id}?") )
+        {
+            await TemplateService.DeleteAsync(id);
+            await Load();
+        }
+    }
+}

--- a/Client.Wasm/Client.Wasm/Program.cs
+++ b/Client.Wasm/Client.Wasm/Program.cs
@@ -26,6 +26,8 @@ builder.Services.AddScoped<Client.Wasm.Services.IGeoApiClient, Client.Wasm.Servi
 builder.Services.AddScoped<Client.Wasm.Services.ITemplateApiClient, Client.Wasm.Services.TemplateApiClient>();
 builder.Services.AddScoped<Client.Wasm.Services.IUserApiClient, Client.Wasm.Services.UserApiClient>();
 builder.Services.AddScoped<Client.Wasm.Services.PreloaderService>();
+builder.Services.AddScoped<Client.Wasm.Services.IDocumentTemplateService, Client.Wasm.Services.DocumentTemplateService>();
+builder.Services.AddScoped<Client.Wasm.Services.DocumentGeneratorService>();
 
 builder.Services.AddBlazoredLocalStorage();
 builder.Services.AddSyncfusionBlazor();

--- a/Client.Wasm/Client.Wasm/Services/DocumentGeneratorService.cs
+++ b/Client.Wasm/Client.Wasm/Services/DocumentGeneratorService.cs
@@ -1,0 +1,14 @@
+namespace Client.Wasm.Services;
+
+public class DocumentGeneratorService
+{
+    public string Generate(string templateContent, Dictionary<string, string> data)
+    {
+        var result = templateContent;
+        foreach (var pair in data)
+        {
+            result = result.Replace($"{{{{{pair.Key}}}}}", pair.Value ?? string.Empty);
+        }
+        return result;
+    }
+}

--- a/Client.Wasm/Client.Wasm/Services/DocumentTemplateService.cs
+++ b/Client.Wasm/Client.Wasm/Services/DocumentTemplateService.cs
@@ -1,0 +1,52 @@
+namespace Client.Wasm.Services;
+
+using System.Net.Http.Json;
+using Client.Wasm.DTOs;
+
+public interface IDocumentTemplateService
+{
+    Task<List<TemplateDto>> GetAllAsync();
+    Task<TemplateDto?> GetByIdAsync(int id);
+    Task<TemplateDto> CreateAsync(CreateTemplateDto dto);
+    Task UpdateAsync(int id, UpdateTemplateDto dto);
+    Task DeleteAsync(int id);
+}
+
+public class DocumentTemplateService : IDocumentTemplateService
+{
+    private readonly HttpClient _http;
+
+    public DocumentTemplateService(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<List<TemplateDto>> GetAllAsync()
+    {
+        return await _http.GetFromJsonAsync<List<TemplateDto>>("api/document-templates") ?? new();
+    }
+
+    public async Task<TemplateDto?> GetByIdAsync(int id)
+    {
+        return await _http.GetFromJsonAsync<TemplateDto>($"api/document-templates/{id}");
+    }
+
+    public async Task<TemplateDto> CreateAsync(CreateTemplateDto dto)
+    {
+        var res = await _http.PostAsJsonAsync("api/document-templates", dto);
+        res.EnsureSuccessStatusCode();
+        return (await res.Content.ReadFromJsonAsync<TemplateDto>())!;
+    }
+
+    public async Task UpdateAsync(int id, UpdateTemplateDto dto)
+    {
+        var res = await _http.PutAsJsonAsync($"api/document-templates/{id}", dto);
+        res.EnsureSuccessStatusCode();
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        var res = await _http.DeleteAsync($"api/document-templates/{id}");
+        res.EnsureSuccessStatusCode();
+    }
+}

--- a/Client.Wasm/Client.Wasm/wwwroot/index.html
+++ b/Client.Wasm/Client.Wasm/wwwroot/index.html
@@ -12,6 +12,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="css/app.css" />
     <link rel="stylesheet" href="css/site.css" />
+    <script src="js/file.js"></script>
     <link rel="icon" type="image/png" href="favicon.png" />
     <link href="Client.Wasm.styles.css" rel="stylesheet" />
     <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />

--- a/Client.Wasm/Client.Wasm/wwwroot/js/file.js
+++ b/Client.Wasm/Client.Wasm/wwwroot/js/file.js
@@ -1,0 +1,8 @@
+window.saveAsFile = (filename, bytesBase64) => {
+    const link = document.createElement('a');
+    link.download = filename;
+    link.href = bytesBase64;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+};

--- a/Server.Api/Server.Api/Controllers/DocumentTemplatesController.cs
+++ b/Server.Api/Server.Api/Controllers/DocumentTemplatesController.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+using GovServices.Server.DTOs;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/document-templates")]
+public class DocumentTemplatesController : ControllerBase
+{
+    private readonly ITemplateService _templates;
+
+    public DocumentTemplatesController(ITemplateService templates)
+    {
+        _templates = templates;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<TemplateDto>>> GetAll()
+    {
+        var list = await _templates.GetAllAsync();
+        return list.Where(t => t.Type == "Word").ToList();
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<TemplateDto>> GetById(int id)
+    {
+        var item = await _templates.GetByIdAsync(id);
+        if (item == null || item.Type != "Word") return NotFound();
+        return item;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<TemplateDto>> Create(CreateTemplateDto dto)
+    {
+        dto.Type = "Word";
+        var result = await _templates.CreateAsync(dto);
+        return CreatedAtAction(nameof(GetById), new { id = result.Id }, result);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Update(int id, UpdateTemplateDto dto)
+    {
+        dto.Type = "Word";
+        await _templates.UpdateAsync(id, dto);
+        return NoContent();
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        await _templates.DeleteAsync(id);
+        return NoContent();
+    }
+}

--- a/Server.Api/Server.Api/DTOs/TemplateDto.cs
+++ b/Server.Api/Server.Api/DTOs/TemplateDto.cs
@@ -5,5 +5,6 @@ namespace GovServices.Server.DTOs
         public int Id { get; set; }
         public string Name { get; set; }
         public string Type { get; set; }
+        public string Content { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
## Summary
- add document templates controller
- extend TemplateDto with `Content`
- add Word processing packages
- implement document template editor and viewer components
- implement services and page to manage Word document templates
- wire up new menu link
- add client JS util for downloads

## Testing
- `dotnet build GovServicesSolution.sln`
- `dotnet test GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_685290a5d5748323af8dd64908835126