### PR TITLE
Implement CryptoPro signing workflow

### DIFF
--- a/Client.Wasm/Client.Wasm/Client.Wasm.csproj
+++ b/Client.Wasm/Client.Wasm/Client.Wasm.csproj
@@ -18,6 +18,8 @@
     <PackageReference Include="Syncfusion.Blazor.Grid" Version="24.1.41" />
     <PackageReference Include="Syncfusion.Blazor.DropDowns" Version="24.1.41" />
     <PackageReference Include="Syncfusion.Blazor.Navigations" Version="24.1.41" />
+    <PackageReference Include="Syncfusion.Blazor.Notifications" Version="24.1.41" />
+    <PackageReference Include="Syncfusion.Blazor.PdfViewer" Version="24.1.41" />
     <PackageReference Include="Syncfusion.Blazor.Popups" Version="24.1.41" />
     <PackageReference Include="Syncfusion.Blazor.Layouts" Version="24.1.41" />
     <PackageReference Include="Syncfusion.Blazor.Charts" Version="24.1.41" />

--- a/Client.Wasm/Client.Wasm/DTOs/DocumentSignatureDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/DocumentSignatureDto.cs
@@ -1,0 +1,7 @@
+namespace Client.Wasm.DTOs;
+
+public class DocumentSignatureDto
+{
+    public Guid DocumentId { get; set; }
+    public string SignatureBase64 { get; set; } = string.Empty;
+}

--- a/Client.Wasm/Client.Wasm/Pages/DocumentSign.razor
+++ b/Client.Wasm/Client.Wasm/Pages/DocumentSign.razor
@@ -1,0 +1,49 @@
+@page "/documents/sign/{Id:guid}"
+@attribute [Authorize]
+@using Client.Wasm.DTOs
+@inject IDocumentApiClient ApiClient
+@inject IJSRuntime Js
+
+<SfCard CssClass="p-6 rounded-xl shadow-lg glass-effect">
+    <CardHeader>
+        <h3 class="mb-4">Подпись документа</h3>
+    </CardHeader>
+    <CardContent>
+        @if (pdfData != null)
+        {
+            <SfPdfViewer DocumentPath="" DocumentBase64="@pdfData" Width="100%" Height="600px"></SfPdfViewer>
+        }
+        <div class="mt-4 flex justify-end">
+            <SfButton CssClass="e-primary" OnClick="Sign">Подписать</SfButton>
+        </div>
+    </CardContent>
+</SfCard>
+
+<SfToast @ref="toast" Timeout="3000"></SfToast>
+
+@code {
+    [Parameter] public Guid Id { get; set; }
+    string? pdfData;
+    SfToast? toast;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        pdfData = await ApiClient.GetBase64Async(Id);
+    }
+
+    async Task Sign()
+    {
+        if (pdfData == null) return;
+        try
+        {
+            var signature = await Js.InvokeAsync<string>("signWithCryptoPro", pdfData);
+            var dto = new DocumentSignatureDto { DocumentId = Id, SignatureBase64 = signature };
+            await ApiClient.UploadSignatureAsync(dto);
+            await toast!.ShowAsync(new ToastModel { Content = "Документ подписан" });
+        }
+        catch (Exception ex)
+        {
+            await toast!.ShowAsync(new ToastModel { Content = "Ошибка подписи: " + ex.Message, CssClass="e-danger" });
+        }
+    }
+}

--- a/Client.Wasm/Client.Wasm/Services/DocumentApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/DocumentApiClient.cs
@@ -8,7 +8,9 @@ public interface IDocumentApiClient
 {
     Task<List<DocumentDto>> GetByOwnerAsync(Guid ownerId);
     Task<DocumentDto?> GetByIdAsync(Guid id);
+    Task<string> GetBase64Async(Guid id);
     Task<Guid> UploadAsync(DocumentUploadDto dto);
+    Task UploadSignatureAsync(DocumentSignatureDto dto);
     Task DeleteAsync(Guid id);
 }
 
@@ -31,6 +33,11 @@ public class DocumentApiClient : IDocumentApiClient
         return await _http.GetFromJsonAsync<DocumentDto>($"api/documents/{id}");
     }
 
+    public async Task<string> GetBase64Async(Guid id)
+    {
+        return await _http.GetStringAsync($"api/documents/base64/{id}");
+    }
+
     public async Task<Guid> UploadAsync(DocumentUploadDto dto)
     {
         using var content = new MultipartFormDataContent();
@@ -42,6 +49,12 @@ public class DocumentApiClient : IDocumentApiClient
         res.EnsureSuccessStatusCode();
         var idStr = await res.Content.ReadAsStringAsync();
         return Guid.Parse(idStr.Trim('"'));
+    }
+
+    public async Task UploadSignatureAsync(DocumentSignatureDto dto)
+    {
+        var res = await _http.PostAsJsonAsync("api/documents/signature", dto);
+        res.EnsureSuccessStatusCode();
     }
 
     public async Task DeleteAsync(Guid id)

--- a/Client.Wasm/Client.Wasm/_Imports.razor
+++ b/Client.Wasm/Client.Wasm/_Imports.razor
@@ -27,5 +27,7 @@
 @using Syncfusion.Blazor.Calendars
 @using Syncfusion.Blazor.Charts
 @using Syncfusion.Blazor.Lists
+@using Syncfusion.Blazor.Notifications
+@using Syncfusion.Blazor.PdfViewer
 @using System.ComponentModel.DataAnnotations
 @using Client.Wasm.Components

--- a/Client.Wasm/Client.Wasm/wwwroot/index.html
+++ b/Client.Wasm/Client.Wasm/wwwroot/index.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="css/app.css" />
     <link rel="stylesheet" href="css/site.css" />
     <script src="js/file.js"></script>
+    <script src="https://www.cryptopro.ru/sites/default/files/products/cadesplugin/cadesplugin_api.js"></script>
     <link rel="icon" type="image/png" href="favicon.png" />
     <link href="Client.Wasm.styles.css" rel="stylesheet" />
     <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />

--- a/Client.Wasm/Client.Wasm/wwwroot/js/file.js
+++ b/Client.Wasm/Client.Wasm/wwwroot/js/file.js
@@ -6,3 +6,31 @@ window.saveAsFile = (filename, bytesBase64) => {
     link.click();
     document.body.removeChild(link);
 };
+
+window.signWithCryptoPro = async (base64) => {
+    return new Promise((resolve, reject) => {
+        const run = function* () {
+            try {
+                const oStore = yield cadesplugin.CreateObjectAsync("CAPICOM.Store");
+                yield oStore.Open(cadesplugin.CAPICOM_CURRENT_USER_STORE, "MY", cadesplugin.CAPICOM_STORE_OPEN_MAXIMUM_ALLOWED);
+                const certs = yield oStore.Certificates;
+                const selected = yield certs.Select("Выбор сертификата", "Выберите сертификат для подписи", false);
+                if (!selected || (yield selected.Count) === 0) throw new Error("Сертификат не выбран");
+                const cert = yield selected.Item(1);
+
+                const signer = yield cadesplugin.CreateObjectAsync("CAdESCOM.CPSigner");
+                yield signer.propset_Certificate(cert);
+
+                const sData = yield cadesplugin.CreateObjectAsync("CAdESCOM.CadesSignedData");
+                yield sData.propset_ContentEncoding(cadesplugin.CADESCOM_BASE64_TO_BINARY);
+                yield sData.propset_Content(base64);
+
+                const signature = yield sData.SignCades(signer, cadesplugin.CADESCOM_CADES_BES, true);
+                resolve(signature);
+            } catch (err) {
+                reject(err.message || err);
+            }
+        };
+        cadesplugin.async_spawn(run);
+    });
+};

--- a/Server.Api/Server.Api/Controllers/DocumentsController.cs
+++ b/Server.Api/Server.Api/Controllers/DocumentsController.cs
@@ -90,6 +90,24 @@ public class DocumentsController : ControllerBase
         return File(stream, doc.MimeType, doc.OriginalName);
     }
 
+    [HttpGet("base64/{id}")]
+    public async Task<ActionResult<string>> GetBase64(Guid id)
+    {
+        var stream = await _storage.GetFileStreamAsync(id);
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms);
+        var bytes = ms.ToArray();
+        return Convert.ToBase64String(bytes);
+    }
+
+    [HttpPost("signature")]
+    [Authorize]
+    public async Task<IActionResult> UploadSignature(DocumentSignatureDto dto)
+    {
+        await _storage.SaveSignatureAsync(dto.DocumentId, dto.SignatureBase64);
+        return Ok();
+    }
+
     [HttpDelete("{id}")]
     [Authorize]
     public async Task<IActionResult> Delete(Guid id)

--- a/Server.Api/Server.Api/DTOs/DocumentSignatureDto.cs
+++ b/Server.Api/Server.Api/DTOs/DocumentSignatureDto.cs
@@ -1,0 +1,7 @@
+namespace GovServices.Server.DTOs;
+
+public class DocumentSignatureDto
+{
+    public Guid DocumentId { get; set; }
+    public string SignatureBase64 { get; set; } = string.Empty;
+}

--- a/Server.Api/Server.Api/Interfaces/IDocumentStorageService.cs
+++ b/Server.Api/Server.Api/Interfaces/IDocumentStorageService.cs
@@ -7,4 +7,5 @@ public interface IDocumentStorageService
     Task<Guid> SaveAsync(DocumentUploadDto dto);
     Task<Stream> GetFileStreamAsync(Guid id);
     Task<bool> DeleteAsync(Guid id);
+    Task SaveSignatureAsync(Guid documentId, string base64);
 }

--- a/Server.Api/Server.Api/Services/DocumentStorageService.cs
+++ b/Server.Api/Server.Api/Services/DocumentStorageService.cs
@@ -101,4 +101,13 @@ public class DocumentStorageService : IDocumentStorageService
         await _db.SaveChangesAsync();
         return true;
     }
+
+    public async Task SaveSignatureAsync(Guid documentId, string base64)
+    {
+        var doc = await _db.Documents.FirstOrDefaultAsync(d => d.Id == documentId)
+                  ?? throw new FileNotFoundException();
+
+        var sigPath = Path.ChangeExtension(doc.StoragePath, ".sig");
+        await File.WriteAllTextAsync(sigPath, base64);
+    }
 }


### PR DESCRIPTION
## Summary
- add `DocumentSignatureDto` for sending signatures
- expose PDF base64 and signature upload endpoints
- store detached signature alongside document
- call CryptoPro signing script from Blazor
- integrate Syncfusion PdfViewer and Toast notifications

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6852984308d88323b50563d087f44d45