### PR TITLE
Fix Client.Wasm build error

### DIFF
--- a/Client.Wasm/Client.Wasm/Client.Wasm.csproj
+++ b/Client.Wasm/Client.Wasm/Client.Wasm.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.17" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Syncfusion.Blazor.Buttons" Version="24.1.41" />


### PR DESCRIPTION
## Summary
- add missing `Microsoft.Extensions.Http` package to Client.Wasm project

## Testing
- `dotnet build GovServicesSolution.sln`
- `dotnet test GovServicesSolution.sln`


------
https://chatgpt.com/codex/tasks/task_e_6852a5942ee48323b1948899ebcba591