### PR TITLE
Register DbContextFactory with Npgsql options

### DIFF
--- a/Server.Api/Server.Api/Program.cs
+++ b/Server.Api/Server.Api/Program.cs
@@ -59,7 +59,9 @@ if (string.IsNullOrWhiteSpace(defaultConn))
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseNpgsql(defaultConn, npgsql => npgsql.UseNetTopologySuite())
 );
-builder.Services.AddDbContextFactory<ApplicationDbContext>();
+builder.Services.AddDbContextFactory<ApplicationDbContext>(options =>
+    options.UseNpgsql(defaultConn, npgsql => npgsql.UseNetTopologySuite())
+);
 
 // JWT configuration
 var jwtKey = builder.Configuration["JwtSettings:SecretKey"];


### PR DESCRIPTION
## Summary
- install .NET 8
- register `IDbContextFactory<ApplicationDbContext>` using `AddDbContextFactory` with the same Npgsql options as the DbContext

## Testing
- `dotnet restore GovServicesSolution.sln`
- `dotnet test GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_6852b7ef93088323b6ff27c4bd183067