### PR TITLE
Fix DbContext and CORS setup

### DIFF
--- a/Server.Api/Server.Api/Migrations/20250618132104_Initial.Designer.cs
+++ b/Server.Api/Server.Api/Migrations/20250618132104_Initial.Designer.cs
@@ -13,8 +13,8 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Server.Api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20250618115745_InitialCreate")]
-    partial class InitialCreate
+    [Migration("20250618132104_Initial")]
+    partial class Initial
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/Server.Api/Server.Api/Migrations/20250618132104_Initial.cs
+++ b/Server.Api/Server.Api/Migrations/20250618132104_Initial.cs
@@ -8,7 +8,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Server.Api.Migrations
 {
     /// <inheritdoc />
-    public partial class InitialCreate : Migration
+    public partial class Initial : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/Server.Api/Server.Api/appsettings.json
+++ b/Server.Api/Server.Api/appsettings.json
@@ -21,8 +21,9 @@
   "AllowedHosts": "*",
   "Cors": {
     "AllowedOrigins": [
+      "http://localhost:5093",
       "https://localhost:5093",
-      "http://localhost:5093"
+      "https://localhost:7197"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- register `ApplicationDbContext` only via `AddDbContextFactory`
- provide scoped `ApplicationDbContext` instances
- read allowed CORS origins from configuration
- update `appsettings.json` with explicit local origins
- regenerate initial EF Core migration

## Testing
- `dotnet build GovServicesSolution.sln`
- `dotnet test Server.Tests/Server.Tests.csproj`
- `dotnet test Client.Wasm.Tests/Client.Wasm.Tests.csproj`
- `dotnet ef database update` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6852bba2f67c8323b152cedd4132c297