### PR TITLE
Fix ErrorBoundary usage

### DIFF
--- a/Client.Wasm/Client.Wasm/App.razor
+++ b/Client.Wasm/Client.Wasm/App.razor
@@ -2,7 +2,10 @@
 @inject NavigationManager NavigationManager
 
 <CascadingAuthenticationState>
-    <ErrorBoundary @ref="errorBoundary" OnError="HandleError">
+    <CustomErrorBoundary @ref="errorBoundary">
+        <ErrorContent>
+            <p class="m-4 text-red-600">Произошла непредвиденная ошибка.</p>
+        </ErrorContent>
         <Router AppAssembly="@typeof(Program).Assembly">
             <Found Context="routeData">
                 <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
@@ -18,17 +21,11 @@
                 <RedirectToLogin />
             </NotFound>
         </Router>
-    </ErrorBoundary>
+    </CustomErrorBoundary>
 </CascadingAuthenticationState>
 
 <ErrorDialog />
 
 @code {
-    ErrorBoundary? errorBoundary;
-    [Inject] ErrorHandlerService ErrorService { get; set; } = default!;
-
-    void HandleError(Exception ex)
-    {
-        ErrorService.Handle(ex);
-    }
+    CustomErrorBoundary? errorBoundary;
 }

--- a/Client.Wasm/Client.Wasm/Components/CustomErrorBoundary.razor
+++ b/Client.Wasm/Client.Wasm/Components/CustomErrorBoundary.razor
@@ -1,0 +1,10 @@
+@inherits ErrorBoundary
+@inject ErrorHandlerService ErrorService
+
+@code {
+    protected override Task OnErrorAsync(Exception exception)
+    {
+        ErrorService.Handle(exception);
+        return base.OnErrorAsync(exception);
+    }
+}


### PR DESCRIPTION
## Summary
- implement a `CustomErrorBoundary` that overrides `OnErrorAsync`
- use it in App.razor and provide `ErrorContent`
- clean up unused code

## Testing
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6852c00fc02c8323b1fc9d6a19a9ac8e