### PR TITLE
Improve CustomErrorBoundary usage

### DIFF
--- a/Client.Wasm/Client.Wasm/App.razor
+++ b/Client.Wasm/Client.Wasm/App.razor
@@ -3,24 +3,26 @@
 
 <CascadingAuthenticationState>
     <CustomErrorBoundary @ref="errorBoundary">
+        <ChildContent>
+            <Router AppAssembly="@typeof(Program).Assembly">
+                <Found Context="routeData">
+                    <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+                        <NotAuthorized>
+                            @if (!NavigationManager.Uri.Contains("/login"))
+                            {
+                                NavigationManager.NavigateTo("/login", forceLoad: true);
+                            }
+                        </NotAuthorized>
+                    </AuthorizeRouteView>
+                </Found>
+                <NotFound>
+                    <RedirectToLogin />
+                </NotFound>
+            </Router>
+        </ChildContent>
         <ErrorContent>
             <p class="m-4 text-red-600">Произошла непредвиденная ошибка.</p>
         </ErrorContent>
-        <Router AppAssembly="@typeof(Program).Assembly">
-            <Found Context="routeData">
-                <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
-                    <NotAuthorized>
-                        @if (!NavigationManager.Uri.Contains("/login"))
-                        {
-                            NavigationManager.NavigateTo("/login", forceLoad: true);
-                        }
-                    </NotAuthorized>
-                </AuthorizeRouteView>
-            </Found>
-            <NotFound>
-                <RedirectToLogin />
-            </NotFound>
-        </Router>
     </CustomErrorBoundary>
 </CascadingAuthenticationState>
 

--- a/Client.Wasm/Client.Wasm/Components/CustomErrorBoundary.razor
+++ b/Client.Wasm/Client.Wasm/Components/CustomErrorBoundary.razor
@@ -1,9 +1,23 @@
 @inherits ErrorBoundary
 @inject ErrorHandlerService ErrorService
+@inject ILogger<CustomErrorBoundary> Logger
+
+@if (CurrentException is not null)
+{
+    @ErrorContent
+}
+else
+{
+    @ChildContent
+}
 
 @code {
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+    [Parameter] public RenderFragment? ErrorContent { get; set; }
+
     protected override Task OnErrorAsync(Exception exception)
     {
+        Logger.LogError(exception, "Unhandled exception in component");
         ErrorService.Handle(exception);
         return base.OnErrorAsync(exception);
     }


### PR DESCRIPTION
## Summary
- implement ChildContent and ErrorContent parameters for `CustomErrorBoundary`
- log exceptions via `ILogger`
- update `App.razor` usage to new error boundary API

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6852c30da89c8323835d0f3c958ae575