### PR TITLE
Fix CustomErrorBoundary parameters

### DIFF
--- a/Client.Wasm/Client.Wasm/Components/CustomErrorBoundary.razor
+++ b/Client.Wasm/Client.Wasm/Components/CustomErrorBoundary.razor
@@ -12,8 +12,8 @@ else
 }
 
 @code {
-    [Parameter] public RenderFragment? ChildContent { get; set; }
-    [Parameter] public RenderFragment? ErrorContent { get; set; }
+    [Parameter] public RenderFragment ChildContent { get; set; }
+    [Parameter] public RenderFragment ErrorContent { get; set; }
 
     protected override Task OnErrorAsync(Exception exception)
     {


### PR DESCRIPTION
## Summary
- ensure ChildContent and ErrorContent parameters aren't duplicated

## Testing
- `dotnet test GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_6852c562d4e48323bdc28359699d9b1b