### PR TITLE
Remove duplicate ChildContent parameter

### DIFF
--- a/Client.Wasm/Client.Wasm/Components/CustomErrorBoundary.razor
+++ b/Client.Wasm/Client.Wasm/Components/CustomErrorBoundary.razor
@@ -12,9 +12,6 @@ else
 }
 
 @code {
-    [Parameter] public RenderFragment ChildContent { get; set; }
-    [Parameter] public RenderFragment ErrorContent { get; set; }
-
     protected override Task OnErrorAsync(Exception exception)
     {
         Logger.LogError(exception, "Unhandled exception in component");


### PR DESCRIPTION
## Summary
- remove duplicate parameter declarations in `CustomErrorBoundary`

## Testing
- `dotnet clean`
- `dotnet build`
- `dotnet run --no-build -p Client.Wasm/Client.Wasm/Client.Wasm.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6852c97aa4a883238b6f780e98393f68