### PR TITLE
Fix http handling and tab headers

### DIFF
--- a/Client.Wasm/Client.Wasm/Helpers/HttpClientExtensions.cs
+++ b/Client.Wasm/Client.Wasm/Helpers/HttpClientExtensions.cs
@@ -1,0 +1,43 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Client.Wasm.Helpers;
+
+public static class HttpClientExtensions
+{
+    public static async Task<T?> GetFromJsonSafeAsync<T>(this HttpClient http, string uri, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var response = await http.GetAsync(uri, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                Console.Error.WriteLine($"GET {uri} failed: {response.StatusCode}");
+                return default;
+            }
+
+            if (response.Content.Headers.ContentLength == 0)
+                return default;
+
+            var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            if (stream == null || stream.Length == 0)
+                return default;
+
+            return await JsonSerializer.DeserializeAsync<T>(stream, options ?? new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            }, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            Console.Error.WriteLine($"GET {uri} threw HttpRequestException: {ex}");
+            return default;
+        }
+        catch (JsonException ex)
+        {
+            Console.Error.WriteLine($"GET {uri} returned invalid JSON: {ex}");
+            return default;
+        }
+    }
+}

--- a/Client.Wasm/Client.Wasm/Pages/ApplicationEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/ApplicationEdit.razor
@@ -12,13 +12,23 @@
         <DataAnnotationsValidator />
         <SfTab>
             <TabItems>
-                <TabItem HeaderText="Основное">
+                <TabItem>
+    <ChildContent>
+        <TabHeader Text="Основное"></TabHeader>
+    </ChildContent>
+    <ContentTemplate>
                     <SfNumericTextBox TValue="int" @bind-Value="model.ServiceId" Placeholder="ID услуги" CssClass="mb-3 w-100" />
                     <SfTextBox TValue="string" Multiline="true" @bind-Value="formData" Placeholder="Данные формы (JSON)" CssClass="mb-3 w-100" Rows="4" />
-                </TabItem>
-                <TabItem HeaderText="Дополнительно">
+                </ContentTemplate>
+</TabItem>
+                <TabItem>
+    <ChildContent>
+        <TabHeader Text="Дополнительно"></TabHeader>
+    </ChildContent>
+    <ContentTemplate>
                     <!-- дополнительные поля -->
-                </TabItem>
+                </ContentTemplate>
+</TabItem>
             </TabItems>
         </SfTab>
         <div class="text-right mt-3">

--- a/Client.Wasm/Client.Wasm/Pages/OrderEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/OrderEdit.razor
@@ -10,11 +10,16 @@
             <DataAnnotationsValidator />
             <SfTab CssClass="e-bootstrap5">
                 <TabItems>
-                    <TabItem HeaderText="Основное">
+                    <TabItem>
+    <ChildContent>
+        <TabHeader Text="Основное"></TabHeader>
+    </ChildContent>
+    <ContentTemplate>
                         <SfTextBox @bind-Value="model.Number" Placeholder="Номер" CssClass="mb-3 w-100" />
                         <SfDatePicker @bind-Value="model.Date" CssClass="mb-3 w-100" />
                         <SfTextBox Multiline="true" @bind-Value="model.Text" Placeholder="Текст" CssClass="mb-3 w-100" Rows="3" />
-                    </TabItem>
+                    </ContentTemplate>
+</TabItem>
                 </TabItems>
             </SfTab>
             <div class="text-right mt-3">

--- a/Client.Wasm/Client.Wasm/Pages/ServiceEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/ServiceEdit.razor
@@ -9,10 +9,15 @@
         <DataAnnotationsValidator />
         <SfTab>
             <TabItems>
-                <TabItem HeaderText="Основное">
+                <TabItem>
+    <ChildContent>
+        <TabHeader Text="Основное"></TabHeader>
+    </ChildContent>
+    <ContentTemplate>
                     <SfTextBox TValue="string" @bind-Value="model.Name" Placeholder="Название" CssClass="mb-3 w-100" />
                     <SfTextBox TValue="string" Multiline="true" @bind-Value="model.Description" Placeholder="Описание" CssClass="mb-3 w-100" Rows="3" />
-                </TabItem>
+                </ContentTemplate>
+</TabItem>
             </TabItems>
         </SfTab>
         <div class="text-right mt-3">

--- a/Client.Wasm/Client.Wasm/Pages/ServiceTemplateEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/ServiceTemplateEdit.razor
@@ -11,13 +11,17 @@
         <DataAnnotationsValidator />
         <SfTab>
             <TabItems>
-                <TabItem HeaderText="Поля">
+                <TabItem>
+    <ChildContent>
+        <TabHeader Text="Поля"></TabHeader>
+    </ChildContent>
+    <ContentTemplate>
                     <SfGrid DataSource="@config.Fields" AllowPaging="false">
                         <GridColumns>
                             <GridColumn Field=@nameof(FieldConfig.Name) HeaderText="Название" Width="150" />
                             <GridColumn Field=@nameof(FieldConfig.Type) HeaderText="Тип" Width="100" />
                             <GridColumn Field=@nameof(FieldConfig.Required) HeaderText="Обяз." Type="ColumnType.Boolean" Width="80" />
-                            <GridColumn HeaderText="" Width="60" TextAlign="TextAlign.Center">
+                            <GridColumn Header="" Width="60" TextAlign="TextAlign.Center">
                                 <Template Context="item">
                                     <SfButton CssClass="e-flat" IconCss="e-icons e-delete" OnClick="@(() => RemoveField(item as FieldConfig))"></SfButton>
                                 </Template>
@@ -27,13 +31,18 @@
                     <div class="mt-2">
                         <SfButton CssClass="e-primary" OnClick="AddField">Добавить поле</SfButton>
                     </div>
-                </TabItem>
-                <TabItem HeaderText="Документы">
+                </ContentTemplate>
+</TabItem>
+                <TabItem>
+    <ChildContent>
+        <TabHeader Text="Документы"></TabHeader>
+    </ChildContent>
+    <ContentTemplate>
                     <SfGrid DataSource="@config.Documents" AllowPaging="false">
                         <GridColumns>
                             <GridColumn Field=@nameof(DocumentConfig.Name) HeaderText="Название" Width="180" />
                             <GridColumn Field=@nameof(DocumentConfig.Required) HeaderText="Обяз." Type="ColumnType.Boolean" Width="80" />
-                            <GridColumn HeaderText="" Width="60" TextAlign="TextAlign.Center">
+                            <GridColumn Header="" Width="60" TextAlign="TextAlign.Center">
                                 <Template Context="doc">
                                     <SfButton CssClass="e-flat" IconCss="e-icons e-delete" OnClick="@(() => RemoveDocument(doc as DocumentConfig))"></SfButton>
                                 </Template>
@@ -43,22 +52,32 @@
                     <div class="mt-2">
                         <SfButton CssClass="e-primary" OnClick="AddDocument">Добавить документ</SfButton>
                     </div>
-                </TabItem>
-                <TabItem HeaderText="Категории">
+                </ContentTemplate>
+</TabItem>
+                <TabItem>
+    <ChildContent>
+        <TabHeader Text="Категории"></TabHeader>
+    </ChildContent>
+    <ContentTemplate>
                     <div class="p-3">
                         @foreach(var cat in categories)
                         {
                             <SfCheckBox TChecked="bool" Label="@cat" Checked="@CategoryChecked(cat)" CheckedChanged="@(val => ToggleCategory(cat, val))" CssClass="mb-2" />
                         }
                     </div>
-                </TabItem>
-                <TabItem HeaderText="Workflow">
+                </ContentTemplate>
+</TabItem>
+                <TabItem>
+    <ChildContent>
+        <TabHeader Text="Workflow"></TabHeader>
+    </ChildContent>
+    <ContentTemplate>
                     <SfGrid DataSource="@config.Workflow" AllowPaging="false">
                         <GridColumns>
                             <GridColumn Field=@nameof(WorkflowStepConfig.Name) HeaderText="Этап" Width="150" />
                             <GridColumn Field=@nameof(WorkflowStepConfig.Role) HeaderText="Роль" Width="150" />
                             <GridColumn Field=@nameof(WorkflowStepConfig.Order) HeaderText="Порядок" Width="80" />
-                            <GridColumn HeaderText="" Width="60" TextAlign="TextAlign.Center">
+                            <GridColumn Header="" Width="60" TextAlign="TextAlign.Center">
                                 <Template Context="step">
                                     <SfButton CssClass="e-flat" IconCss="e-icons e-delete" OnClick="@(() => RemoveStep(step as WorkflowStepConfig))"></SfButton>
                                 </Template>
@@ -68,8 +87,13 @@
                     <div class="mt-2">
                         <SfButton CssClass="e-primary" OnClick="AddStep">Добавить этап</SfButton>
                     </div>
-                </TabItem>
-                <TabItem HeaderText="Превью">
+                </ContentTemplate>
+</TabItem>
+                <TabItem>
+    <ChildContent>
+        <TabHeader Text="Превью"></TabHeader>
+    </ChildContent>
+    <ContentTemplate>
                     <div class="p-3">
                         @foreach(var f in config.Fields.OrderBy(f => f.Order))
                         {
@@ -90,7 +114,8 @@
                             </div>
                         }
                     </div>
-                </TabItem>
+                </ContentTemplate>
+</TabItem>
             </TabItems>
         </SfTab>
         <div class="text-right mt-3">

--- a/Client.Wasm/Client.Wasm/Pages/TemplateEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/TemplateEdit.razor
@@ -12,14 +12,24 @@
         <DataAnnotationsValidator />
         <SfTab>
             <TabItems>
-                <TabItem HeaderText="Основное">
+                <TabItem>
+    <ChildContent>
+        <TabHeader Text="Основное"></TabHeader>
+    </ChildContent>
+    <ContentTemplate>
                     <SfTextBox TValue="string" @bind-Value="model.Name" Placeholder="Название" CssClass="mb-3 w-100" />
                     <SfTextBox TValue="string" @bind-Value="model.Type" Placeholder="Тип" CssClass="mb-3 w-100" />
                     <SfTextBox TValue="string" Multiline="true" @bind-Value="model.Content" Placeholder="Содержимое" CssClass="mb-3 w-100" Rows="6" />
-                </TabItem>
-                <TabItem HeaderText="Дополнительно">
+                </ContentTemplate>
+</TabItem>
+                <TabItem>
+    <ChildContent>
+        <TabHeader Text="Дополнительно"></TabHeader>
+    </ChildContent>
+    <ContentTemplate>
                     <!-- дополнительные поля -->
-                </TabItem>
+                </ContentTemplate>
+</TabItem>
             </TabItems>
         </SfTab>
         <div class="text-right mt-3">

--- a/Client.Wasm/Client.Wasm/Pages/UserEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/UserEdit.razor
@@ -12,15 +12,25 @@
         <DataAnnotationsValidator />
         <SfTab>
             <TabItems>
-                <TabItem HeaderText="Основное">
+                <TabItem>
+    <ChildContent>
+        <TabHeader Text="Основное"></TabHeader>
+    </ChildContent>
+    <ContentTemplate>
                     <SfTextBox TValue="string" @bind-Value="model.Email" Placeholder="Email" CssClass="mb-3 w-100" />
                     <SfTextBox TValue="string" @bind-Value="model.FullName" Placeholder="ФИО" CssClass="mb-3 w-100" />
                     <SfNumericTextBox TValue="int" @bind-Value="model.DepartmentId" Placeholder="ID отдела" CssClass="mb-3 w-100" />
                     <SfTextBox TValue="string" @bind-Value="roles" Placeholder="Роли (через запятую)" CssClass="mb-3 w-100" />
-                </TabItem>
-                <TabItem HeaderText="Дополнительно">
+                </ContentTemplate>
+</TabItem>
+                <TabItem>
+    <ChildContent>
+        <TabHeader Text="Дополнительно"></TabHeader>
+    </ChildContent>
+    <ContentTemplate>
                     <!-- дополнительные поля -->
-                </TabItem>
+                </ContentTemplate>
+</TabItem>
             </TabItems>
         </SfTab>
         <div class="text-right mt-3">

--- a/Client.Wasm/Client.Wasm/Pages/Weather.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Weather.razor
@@ -1,6 +1,7 @@
 @attribute [Authorize]
 @page "/weather"
 @inject HttpClient Http
+@using Client.Wasm.Helpers
 
 <div class="container p-4">
     <SfCard CssClass="mb-4">
@@ -32,7 +33,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        forecasts = await Http.GetFromJsonAsync<WeatherForecast[]>("sample-data/weather.json");
+        forecasts = await Http.GetFromJsonSafeAsync<WeatherForecast[]>("sample-data/weather.json");
     }
 
     public class WeatherForecast

--- a/Client.Wasm/Client.Wasm/Pages/WorkflowEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/WorkflowEdit.razor
@@ -12,13 +12,23 @@
         <DataAnnotationsValidator />
         <SfTab>
             <TabItems>
-                <TabItem HeaderText="Основное">
+                <TabItem>
+    <ChildContent>
+        <TabHeader Text="Основное"></TabHeader>
+    </ChildContent>
+    <ContentTemplate>
                     <SfTextBox TValue="string" @bind-Value="model.Name" Placeholder="Название" CssClass="mb-3 w-100" />
                     <SfTextBox TValue="string" Multiline="true" @bind-Value="model.Description" Placeholder="Описание" CssClass="mb-3 w-100" Rows="4" />
-                </TabItem>
-                <TabItem HeaderText="Дополнительно">
+                </ContentTemplate>
+</TabItem>
+                <TabItem>
+    <ChildContent>
+        <TabHeader Text="Дополнительно"></TabHeader>
+    </ChildContent>
+    <ContentTemplate>
                     <!-- дополнительные поля -->
-                </TabItem>
+                </ContentTemplate>
+</TabItem>
             </TabItems>
         </SfTab>
         <div class="text-right mt-3">

--- a/Client.Wasm/Client.Wasm/Services/ApplicationApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/ApplicationApiClient.cs
@@ -2,6 +2,7 @@ namespace Client.Wasm.Services;
 
 using System.Net.Http.Json;
 using Client.Wasm.DTOs;
+using Client.Wasm.Helpers;
 
 public interface IApplicationApiClient
 {
@@ -33,12 +34,13 @@ public class ApplicationApiClient : IApplicationApiClient
 
     public async Task<List<ApplicationDto>> GetAllAsync()
     {
-        return await _http.GetFromJsonAsync<List<ApplicationDto>>("api/applications") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<ApplicationDto>>("api/applications");
+        return result ?? new();
     }
 
     public async Task<ApplicationDto?> GetByIdAsync(int id)
     {
-        return await _http.GetFromJsonAsync<ApplicationDto>($"api/applications/{id}");
+        return await _http.GetFromJsonSafeAsync<ApplicationDto>($"api/applications/{id}");
     }
 
     public async Task<ApplicationDto> CreateAsync(CreateApplicationDto dto)
@@ -68,12 +70,14 @@ public class ApplicationApiClient : IApplicationApiClient
 
     public async Task<List<ApplicationLogDto>> GetLogsAsync(int applicationId)
     {
-        return await _http.GetFromJsonAsync<List<ApplicationLogDto>>($"api/applications/{applicationId}/logs") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<ApplicationLogDto>>($"api/applications/{applicationId}/logs");
+        return result ?? new();
     }
 
     public async Task<List<ApplicationResultDto>> GetResultsAsync(int applicationId)
     {
-        return await _http.GetFromJsonAsync<List<ApplicationResultDto>>($"api/applications/{applicationId}/results") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<ApplicationResultDto>>($"api/applications/{applicationId}/results");
+        return result ?? new();
     }
 
     public async Task<ApplicationResultDto> AddResultAsync(CreateApplicationResultDto dto)
@@ -85,7 +89,8 @@ public class ApplicationApiClient : IApplicationApiClient
 
     public async Task<List<ApplicationRevisionDto>> GetRevisionsAsync(int applicationId)
     {
-        return await _http.GetFromJsonAsync<List<ApplicationRevisionDto>>($"api/applications/{applicationId}/revisions") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<ApplicationRevisionDto>>($"api/applications/{applicationId}/revisions");
+        return result ?? new();
     }
 
     public async Task<ApplicationRevisionDto> AddRevisionAsync(CreateApplicationRevisionDto dto)
@@ -97,16 +102,19 @@ public class ApplicationApiClient : IApplicationApiClient
 
     public async Task<List<ApplicationDto>> GetRelatedByApplicantAsync(int applicationId)
     {
-        return await _http.GetFromJsonAsync<List<ApplicationDto>>($"api/applications/{applicationId}/related/applicant") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<ApplicationDto>>($"api/applications/{applicationId}/related/applicant");
+        return result ?? new();
     }
 
     public async Task<List<ApplicationDto>> GetRelatedByRepresentativeAsync(int applicationId)
     {
-        return await _http.GetFromJsonAsync<List<ApplicationDto>>($"api/applications/{applicationId}/related/representative") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<ApplicationDto>>($"api/applications/{applicationId}/related/representative");
+        return result ?? new();
     }
 
     public async Task<List<ApplicationDto>> GetRelatedByGeoAsync(int applicationId)
     {
-        return await _http.GetFromJsonAsync<List<ApplicationDto>>($"api/applications/{applicationId}/related/geo") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<ApplicationDto>>($"api/applications/{applicationId}/related/geo");
+        return result ?? new();
     }
 }

--- a/Client.Wasm/Client.Wasm/Services/DictionaryApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/DictionaryApiClient.cs
@@ -3,6 +3,7 @@ namespace Client.Wasm.Services;
 using System.Net.Http.Json;
 using Client.Wasm.DTOs;
 using Microsoft.AspNetCore.Components.Forms;
+using Client.Wasm.Helpers;
 
 public interface IDictionaryApiClient
 {
@@ -21,7 +22,8 @@ public class DictionaryApiClient : IDictionaryApiClient
 
     public async Task<List<DictionaryDto>> GetAllAsync()
     {
-        return await _http.GetFromJsonAsync<List<DictionaryDto>>("api/dictionaries") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<DictionaryDto>>("api/dictionaries");
+        return result ?? new();
     }
 
     public async Task<int> UploadAsync(UploadDictionaryDto dto)

--- a/Client.Wasm/Client.Wasm/Services/DocumentApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/DocumentApiClient.cs
@@ -3,6 +3,7 @@ namespace Client.Wasm.Services;
 using System.Net.Http.Json;
 using Client.Wasm.DTOs;
 using Microsoft.AspNetCore.Components.Forms;
+using Client.Wasm.Helpers;
 
 public interface IDocumentApiClient
 {
@@ -25,12 +26,13 @@ public class DocumentApiClient : IDocumentApiClient
 
     public async Task<List<DocumentDto>> GetByOwnerAsync(Guid ownerId)
     {
-        return await _http.GetFromJsonAsync<List<DocumentDto>>($"api/documents/owner/{ownerId}") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<DocumentDto>>($"api/documents/owner/{ownerId}");
+        return result ?? new();
     }
 
     public async Task<DocumentDto?> GetByIdAsync(Guid id)
     {
-        return await _http.GetFromJsonAsync<DocumentDto>($"api/documents/{id}");
+        return await _http.GetFromJsonSafeAsync<DocumentDto>($"api/documents/{id}");
     }
 
     public async Task<string> GetBase64Async(Guid id)

--- a/Client.Wasm/Client.Wasm/Services/DocumentTemplateService.cs
+++ b/Client.Wasm/Client.Wasm/Services/DocumentTemplateService.cs
@@ -2,6 +2,7 @@ namespace Client.Wasm.Services;
 
 using System.Net.Http.Json;
 using Client.Wasm.DTOs;
+using Client.Wasm.Helpers;
 
 public interface IDocumentTemplateService
 {
@@ -23,12 +24,13 @@ public class DocumentTemplateService : IDocumentTemplateService
 
     public async Task<List<TemplateDto>> GetAllAsync()
     {
-        return await _http.GetFromJsonAsync<List<TemplateDto>>("api/document-templates") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<TemplateDto>>("api/document-templates");
+        return result ?? new();
     }
 
     public async Task<TemplateDto?> GetByIdAsync(int id)
     {
-        return await _http.GetFromJsonAsync<TemplateDto>($"api/document-templates/{id}");
+        return await _http.GetFromJsonSafeAsync<TemplateDto>($"api/document-templates/{id}");
     }
 
     public async Task<TemplateDto> CreateAsync(CreateTemplateDto dto)

--- a/Client.Wasm/Client.Wasm/Services/GeoApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/GeoApiClient.cs
@@ -2,6 +2,7 @@ namespace Client.Wasm.Services;
 
 using System.Net.Http.Json;
 using Client.Wasm.DTOs;
+using Client.Wasm.Helpers;
 
 public interface IGeoApiClient
 {
@@ -23,12 +24,13 @@ public class GeoApiClient : IGeoApiClient
 
     public async Task<List<GeoObjectDto>> GetAllAsync()
     {
-        return await _http.GetFromJsonAsync<List<GeoObjectDto>>("api/geoobjects") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<GeoObjectDto>>("api/geoobjects");
+        return result ?? new();
     }
 
     public async Task<GeoObjectDto?> GetByIdAsync(int id)
     {
-        return await _http.GetFromJsonAsync<GeoObjectDto>($"api/geoobjects/{id}");
+        return await _http.GetFromJsonSafeAsync<GeoObjectDto>($"api/geoobjects/{id}");
     }
 
     public async Task<GeoObjectDto> CreateAsync(CreateGeoObjectDto dto)
@@ -40,7 +42,8 @@ public class GeoApiClient : IGeoApiClient
 
     public async Task<List<GeoObjectDto>> GetIntersectingAsync(string wkt)
     {
-        return await _http.GetFromJsonAsync<List<GeoObjectDto>>($"api/geoobjects/intersect?wkt={Uri.EscapeDataString(wkt)}") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<GeoObjectDto>>($"api/geoobjects/intersect?wkt={Uri.EscapeDataString(wkt)}");
+        return result ?? new();
     }
 
     public async Task DeleteAsync(int id)

--- a/Client.Wasm/Client.Wasm/Services/IntegrationApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/IntegrationApiClient.cs
@@ -2,6 +2,7 @@ namespace Client.Wasm.Services;
 
 using System.Net.Http.Json;
 using Client.Wasm.DTOs;
+using Client.Wasm.Helpers;
 
 public interface IIntegrationApiClient
 {
@@ -33,7 +34,8 @@ public class IntegrationApiClient : IIntegrationApiClient
 
     public async Task<RosreestrRequestDto> GetRosreestrStatusAsync(string requestId)
     {
-        return await _http.GetFromJsonAsync<RosreestrRequestDto>($"api/integrations/rosreestr/status/{requestId}") ?? new RosreestrRequestDto();
+        var result = await _http.GetFromJsonSafeAsync<RosreestrRequestDto>($"api/integrations/rosreestr/status/{requestId}");
+        return result ?? new RosreestrRequestDto();
     }
 
     public async Task<ZagsRequestDto> SendZagsRequestAsync(CreateZagsRequestDto dto)
@@ -45,12 +47,14 @@ public class IntegrationApiClient : IIntegrationApiClient
 
     public async Task<ZagsRequestDto> GetZagsStatusAsync(string requestId)
     {
-        return await _http.GetFromJsonAsync<ZagsRequestDto>($"api/integrations/zags/status/{requestId}") ?? new ZagsRequestDto();
+        var result = await _http.GetFromJsonSafeAsync<ZagsRequestDto>($"api/integrations/zags/status/{requestId}");
+        return result ?? new ZagsRequestDto();
     }
 
     public async Task<List<SedDocumentLogDto>> GetSedLogsAsync(int applicationId)
     {
-        return await _http.GetFromJsonAsync<List<SedDocumentLogDto>>($"api/integrations/sed/{applicationId}/logs") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<SedDocumentLogDto>>($"api/integrations/sed/{applicationId}/logs");
+        return result ?? new();
     }
 
     public async Task<bool> SendSedDocumentAsync(int applicationId, string documentNumber)

--- a/Client.Wasm/Client.Wasm/Services/NumberTemplateApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/NumberTemplateApiClient.cs
@@ -2,6 +2,7 @@ namespace Client.Wasm.Services;
 
 using System.Net.Http.Json;
 using Client.Wasm.DTOs;
+using Client.Wasm.Helpers;
 
 public interface INumberTemplateApiClient
 {
@@ -18,10 +19,13 @@ public class NumberTemplateApiClient : INumberTemplateApiClient
     public NumberTemplateApiClient(HttpClient http) => _http = http;
 
     public async Task<List<NumberTemplateDto>> GetAllAsync()
-        => await _http.GetFromJsonAsync<List<NumberTemplateDto>>("api/number-templates") ?? new();
+    {
+        var result = await _http.GetFromJsonSafeAsync<List<NumberTemplateDto>>("api/number-templates");
+        return result ?? new();
+    }
 
     public async Task<NumberTemplateDto?> GetByIdAsync(int id)
-        => await _http.GetFromJsonAsync<NumberTemplateDto>($"api/number-templates/{id}");
+        => await _http.GetFromJsonSafeAsync<NumberTemplateDto>($"api/number-templates/{id}");
 
     public async Task<NumberTemplateDto> CreateAsync(CreateNumberTemplateDto dto)
     {

--- a/Client.Wasm/Client.Wasm/Services/OutgoingApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/OutgoingApiClient.cs
@@ -2,6 +2,7 @@ namespace Client.Wasm.Services;
 
 using System.Net.Http.Json;
 using Client.Wasm.DTOs;
+using Client.Wasm.Helpers;
 
 public interface IOutgoingApiClient
 {
@@ -22,12 +23,13 @@ public class OutgoingApiClient : IOutgoingApiClient
 
     public async Task<List<OutgoingDocumentDto>> GetByApplicationIdAsync(int applicationId)
     {
-        return await _http.GetFromJsonAsync<List<OutgoingDocumentDto>>($"api/applications/{applicationId}/outgoing") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<OutgoingDocumentDto>>($"api/applications/{applicationId}/outgoing");
+        return result ?? new();
     }
 
     public async Task<OutgoingDocumentDto?> GetByIdAsync(int id)
     {
-        return await _http.GetFromJsonAsync<OutgoingDocumentDto>($"api/outgoing/{id}");
+        return await _http.GetFromJsonSafeAsync<OutgoingDocumentDto>($"api/outgoing/{id}");
     }
 
     public async Task<OutgoingDocumentDto> CreateAsync(int applicationId, Stream fileStream, string fileName, IEnumerable<(Stream stream, string fileName)> attachments)

--- a/Client.Wasm/Client.Wasm/Services/PermissionGroupApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/PermissionGroupApiClient.cs
@@ -2,6 +2,7 @@ namespace Client.Wasm.Services;
 
 using System.Net.Http.Json;
 using Client.Wasm.DTOs;
+using Client.Wasm.Helpers;
 
 public interface IPermissionGroupApiClient
 {
@@ -19,6 +20,7 @@ public class PermissionGroupApiClient : IPermissionGroupApiClient
 
     public async Task<List<PermissionGroupDto>> GetAllAsync()
     {
-        return await _http.GetFromJsonAsync<List<PermissionGroupDto>>("api/permissiongroups") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<PermissionGroupDto>>("api/permissiongroups");
+        return result ?? new();
     }
 }

--- a/Client.Wasm/Client.Wasm/Services/ServiceApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/ServiceApiClient.cs
@@ -2,6 +2,7 @@ namespace Client.Wasm.Services;
 
 using System.Net.Http.Json;
 using Client.Wasm.DTOs;
+using Client.Wasm.Helpers;
 
 public interface IServiceApiClient
 {
@@ -23,12 +24,13 @@ public class ServiceApiClient : IServiceApiClient
 
     public async Task<List<ServiceDto>> GetAllAsync()
     {
-        return await _http.GetFromJsonAsync<List<ServiceDto>>("api/services") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<ServiceDto>>("api/services");
+        return result ?? new();
     }
 
     public async Task<ServiceDto?> GetByIdAsync(int id)
     {
-        return await _http.GetFromJsonAsync<ServiceDto>($"api/services/{id}");
+        return await _http.GetFromJsonSafeAsync<ServiceDto>($"api/services/{id}");
     }
 
     public async Task<ServiceDto> CreateAsync(CreateServiceDto dto)

--- a/Client.Wasm/Client.Wasm/Services/ServiceTemplateApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/ServiceTemplateApiClient.cs
@@ -2,6 +2,7 @@ namespace Client.Wasm.Services;
 
 using System.Net.Http.Json;
 using Client.Wasm.DTOs;
+using Client.Wasm.Helpers;
 
 public interface IServiceTemplateApiClient
 {
@@ -23,12 +24,13 @@ public class ServiceTemplateApiClient : IServiceTemplateApiClient
 
     public async Task<List<ServiceTemplateDto>> GetAllAsync()
     {
-        return await _http.GetFromJsonAsync<List<ServiceTemplateDto>>("api/servicetemplates") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<ServiceTemplateDto>>("api/servicetemplates");
+        return result ?? new();
     }
 
     public async Task<ServiceTemplateDto?> GetByIdAsync(int id)
     {
-        return await _http.GetFromJsonAsync<ServiceTemplateDto>($"api/servicetemplates/{id}");
+        return await _http.GetFromJsonSafeAsync<ServiceTemplateDto>($"api/servicetemplates/{id}");
     }
 
     public async Task<ServiceTemplateDto> CreateAsync(CreateServiceTemplateDto dto)

--- a/Client.Wasm/Client.Wasm/Services/TemplateApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/TemplateApiClient.cs
@@ -2,6 +2,7 @@ namespace Client.Wasm.Services;
 
 using System.Net.Http.Json;
 using Client.Wasm.DTOs;
+using Client.Wasm.Helpers;
 
 public interface ITemplateApiClient
 {
@@ -24,12 +25,13 @@ public class TemplateApiClient : ITemplateApiClient
 
     public async Task<List<TemplateDto>> GetAllAsync()
     {
-        return await _http.GetFromJsonAsync<List<TemplateDto>>("api/templates") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<TemplateDto>>("api/templates");
+        return result ?? new();
     }
 
     public async Task<TemplateDto?> GetByIdAsync(int id)
     {
-        return await _http.GetFromJsonAsync<TemplateDto>($"api/templates/{id}");
+        return await _http.GetFromJsonSafeAsync<TemplateDto>($"api/templates/{id}");
     }
 
     public async Task<TemplateDto> CreateAsync(CreateTemplateDto dto)

--- a/Client.Wasm/Client.Wasm/Services/UserApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/UserApiClient.cs
@@ -2,6 +2,7 @@ namespace Client.Wasm.Services;
 
 using System.Net.Http.Json;
 using Client.Wasm.DTOs;
+using Client.Wasm.Helpers;
 
 public interface IUserApiClient
 {
@@ -24,12 +25,13 @@ public class UserApiClient : IUserApiClient
 
     public async Task<List<UserDto>> GetAllAsync()
     {
-        return await _http.GetFromJsonAsync<List<UserDto>>("api/users") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<UserDto>>("api/users");
+        return result ?? new();
     }
 
     public async Task<UserDto?> GetByIdAsync(string id)
     {
-        return await _http.GetFromJsonAsync<UserDto>($"api/users/{id}");
+        return await _http.GetFromJsonSafeAsync<UserDto>($"api/users/{id}");
     }
 
     public async Task<UserDto> CreateAsync(CreateUserDto dto)

--- a/Client.Wasm/Client.Wasm/Services/WorkflowApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/WorkflowApiClient.cs
@@ -2,6 +2,7 @@ namespace Client.Wasm.Services;
 
 using System.Net.Http.Json;
 using Client.Wasm.DTOs;
+using Client.Wasm.Helpers;
 
 public interface IWorkflowApiClient
 {
@@ -25,12 +26,13 @@ public class WorkflowApiClient : IWorkflowApiClient
 
     public async Task<List<WorkflowDto>> GetAllWorkflowsAsync()
     {
-        return await _http.GetFromJsonAsync<List<WorkflowDto>>("api/workflow") ?? new();
+        var result = await _http.GetFromJsonSafeAsync<List<WorkflowDto>>("api/workflow");
+        return result ?? new();
     }
 
     public async Task<WorkflowDto?> GetByIdAsync(int id)
     {
-        return await _http.GetFromJsonAsync<WorkflowDto>($"api/workflow/{id}");
+        return await _http.GetFromJsonSafeAsync<WorkflowDto>($"api/workflow/{id}");
     }
 
     public async Task<WorkflowDto> CreateAsync(WorkflowDto dto)


### PR DESCRIPTION
## Summary
- add `GetFromJsonSafeAsync` with safety checks
- use new helper across API clients and Weather page
- fix all Syncfusion `<TabItem>` headers to use `<TabHeader>`
- update grid column header attributes as needed

## Testing
- `dotnet build --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68531927508c8323969f823be5a53949