### PR TITLE
Enhance JWT parsing and auth

### DIFF
--- a/Client.Wasm.Tests/AuthServiceTests.cs
+++ b/Client.Wasm.Tests/AuthServiceTests.cs
@@ -31,7 +31,8 @@ public class AuthServiceTests
         storageMock.Setup(s => s.SetItemAsync<string>("authToken", It.IsAny<string>()))
             .Returns(ValueTask.CompletedTask);
 
-        var provider = new CustomAuthStateProvider(storageMock.Object, http);
+        var logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<CustomAuthStateProvider>.Instance;
+        var provider = new CustomAuthStateProvider(storageMock.Object, http, logger);
         var service = new AuthService(http, provider);
 
         var success = await service.LoginAsync(dto);
@@ -50,7 +51,8 @@ public class AuthServiceTests
         http.BaseAddress = new Uri("http://localhost");
 
         var storageMock = new Mock<ILocalStorageService>();
-        var provider = new CustomAuthStateProvider(storageMock.Object, http);
+        var logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<CustomAuthStateProvider>.Instance;
+        var provider = new CustomAuthStateProvider(storageMock.Object, http, logger);
         var service = new AuthService(http, provider);
 
         var success = await service.LoginAsync(new LoginRequestDto());

--- a/Client.Wasm.Tests/LoginPageTests.razor.cs
+++ b/Client.Wasm.Tests/LoginPageTests.razor.cs
@@ -24,7 +24,8 @@ public class LoginPageTests : TestContext
         var handler = new MockHttpMessageHandler();
         var http = handler.ToHttpClient();
         var storageMock = new Mock<ILocalStorageService>();
-        var authService = new AuthService(http, new CustomAuthStateProvider(storageMock.Object, http));
+        var logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<CustomAuthStateProvider>.Instance;
+        var authService = new AuthService(http, new CustomAuthStateProvider(storageMock.Object, http, logger));
         Services.AddSingleton(authService);
         Services.AddSingleton<IAuthService>(authService);
         Services.AddSingleton<AuthenticationStateProvider>(new TestAuthenticationStateProvider());
@@ -48,7 +49,8 @@ public class LoginPageTests : TestContext
         var http = handler.ToHttpClient();
         http.BaseAddress = new Uri("http://localhost");
         var storageMock = new Mock<ILocalStorageService>();
-        var authService = new AuthService(http, new CustomAuthStateProvider(storageMock.Object, http));
+        var logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<CustomAuthStateProvider>.Instance;
+        var authService = new AuthService(http, new CustomAuthStateProvider(storageMock.Object, http, logger));
         Services.AddSingleton(authService);
         Services.AddSingleton<IAuthService>(authService);
         Services.AddSingleton<AuthenticationStateProvider>(new TestAuthenticationStateProvider());

--- a/Client.Wasm/Client.Wasm/Helpers/JwtParser.cs
+++ b/Client.Wasm/Client.Wasm/Helpers/JwtParser.cs
@@ -7,23 +7,61 @@ public static class JwtParser
 {
     public static IEnumerable<Claim> ParseClaimsFromJwt(string jwt)
     {
-        var payload = jwt.Split('.')[1];
-        var jsonBytes = ParseBase64WithoutPadding(payload);
-        var keyValuePairs = JsonSerializer.Deserialize<Dictionary<string, object>>(jsonBytes);
-        if (keyValuePairs == null)
+        if (string.IsNullOrWhiteSpace(jwt))
         {
             return Enumerable.Empty<Claim>();
         }
-        return keyValuePairs.Select(kvp => new Claim(kvp.Key, kvp.Value.ToString() ?? string.Empty));
+
+        var parts = jwt.Split('.');
+        if (parts.Length != 3)
+        {
+            Console.Error.WriteLine($"JWT has invalid format: {jwt}");
+            return Enumerable.Empty<Claim>();
+        }
+
+        try
+        {
+            var jsonBytes = ParseBase64WithoutPadding(parts[1]);
+            var keyValuePairs = JsonSerializer.Deserialize<Dictionary<string, object>>(jsonBytes);
+            if (keyValuePairs == null)
+            {
+                return Enumerable.Empty<Claim>();
+            }
+            return keyValuePairs.Select(kvp => new Claim(kvp.Key, kvp.Value?.ToString() ?? string.Empty));
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to parse JWT: {ex}. Token: {jwt}");
+            return Enumerable.Empty<Claim>();
+        }
     }
 
     private static byte[] ParseBase64WithoutPadding(string base64)
     {
+        base64 = base64.Replace('-', '+').Replace('_', '/');
+
         switch (base64.Length % 4)
         {
-            case 2: base64 += "=="; break;
-            case 3: base64 += "="; break;
+            case 0:
+                break;
+            case 2:
+                base64 += "==";
+                break;
+            case 3:
+                base64 += "=";
+                break;
+            default:
+                throw new FormatException("Invalid Base64 string length.");
         }
-        return Convert.FromBase64String(base64);
+
+        try
+        {
+            return Convert.FromBase64String(base64);
+        }
+        catch (FormatException ex)
+        {
+            Console.Error.WriteLine($"Invalid base64 string: {base64}. {ex}");
+            throw;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- harden JWT parsing with url-safe Base64 support, length validation, and error logging
- improve `CustomAuthStateProvider` to gracefully handle malformed tokens
- update unit tests to use logger

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6853fd10441483239f9167200fb48a80