### PR TITLE
Improve menu with dynamic grouping

### DIFF
--- a/Client.Wasm/Client.Wasm/Components/Sidebar.razor
+++ b/Client.Wasm/Client.Wasm/Components/Sidebar.razor
@@ -1,6 +1,6 @@
-<SfAccordion CssClass="sidebar-menu" ExpandMode="ExpandMode.Multiple">
+<SfAccordion CssClass="sidebar-menu rounded-xl shadow-lg bg-white" ExpandMode="ExpandMode.Multiple">
     <AccordionItems>
-        @foreach (var group in Groups)
+        @foreach (var group in Menu.Groups)
         {
             <AccordionItem Header=@group.Title>
                 <ContentTemplate>
@@ -21,18 +21,6 @@
 </SfAccordion>
 
 @code {
-    [Parameter]
-    public List<MenuGroup> Groups { get; set; } = new();
-
-    public class MenuGroup
-    {
-        public string Title { get; set; } = string.Empty;
-        public List<MenuItem> Items { get; set; } = new();
-    }
-
-    public class MenuItem
-    {
-        public string Title { get; set; } = string.Empty;
-        public string Url { get; set; } = string.Empty;
-    }
+    [Inject]
+    public MenuService Menu { get; set; } = default!;
 }

--- a/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
+++ b/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
@@ -34,7 +34,7 @@
 </CascadingAuthenticationState>
 
 <SfSidebar @ref="sidebar" Type="SidebarType.Push" Width="250px" CssClass="sidebar" MediaQuery="(min-width:768px)">
-    <Sidebar Groups="MenuGroups" />
+    <Sidebar />
 </SfSidebar>
 
 <div class="content @(Nav.Uri.Contains("/login") ? "login-content" : "p-4")">
@@ -57,74 +57,6 @@
         authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
     }
     SfSidebar sidebar;
-
-    List<Sidebar.MenuGroup> MenuGroups = new()
-    {
-        new Sidebar.MenuGroup
-        {
-            Title = "Заявления",
-            Items = new()
-            {
-                new Sidebar.MenuItem { Title = "Все", Url = "/applications" },
-                new Sidebar.MenuItem { Title = "Реестр заявлений", Url = "/registry/applications" },
-                new Sidebar.MenuItem { Title = "Распоряжения РДЗ", Url = "/registry/rdz-orders" },
-                new Sidebar.MenuItem { Title = "Распоряжения РДИ", Url = "/registry/rdi-orders" }
-            }
-        },
-        new Sidebar.MenuGroup
-        {
-            Title = "Документы",
-            Items = new()
-            {
-                new Sidebar.MenuItem { Title = "Все документы", Url = "/documents/0" },
-                new Sidebar.MenuItem { Title = "Договоры", Url = "/registry/contracts" },
-                new Sidebar.MenuItem { Title = "Акты", Url = "/registry/acts" },
-                new Sidebar.MenuItem { Title = "Соглашения", Url = "/registry/agreements" },
-                new Sidebar.MenuItem { Title = "Ответы", Url = "/registry/answers" },
-                new Sidebar.MenuItem { Title = "Канцелярия", Url = "/registry/clerical" }
-            }
-        },
-        new Sidebar.MenuGroup
-        {
-            Title = "Администрирование",
-            Items = new()
-            {
-                new Sidebar.MenuItem { Title = "Сервисы", Url = "/services" },
-                new Sidebar.MenuItem { Title = "Шаблоны услуг", Url = "/service-templates" },
-                new Sidebar.MenuItem { Title = "Рабочие процессы", Url = "/workflows" },
-                new Sidebar.MenuItem { Title = "Шаблоны документов", Url = "/document-templates" },
-                new Sidebar.MenuItem { Title = "Пользователи", Url = "/users" },
-                new Sidebar.MenuItem { Title = "Группы прав", Url = "/permission-groups" },
-                new Sidebar.MenuItem { Title = "Шаблоны номеров", Url = "/number-templates" },
-                new Sidebar.MenuItem { Title = "Справочники", Url = "/dictionaries" }
-            }
-        },
-        new Sidebar.MenuGroup
-        {
-            Title = "Отчеты",
-            Items = new()
-            {
-                new Sidebar.MenuItem { Title = "Дашборд", Url = "/dashboard" }
-            }
-        },
-        new Sidebar.MenuGroup
-        {
-            Title = "Настройки",
-            Items = new()
-            {
-                new Sidebar.MenuItem { Title = "Профиль", Url = "/profile" },
-                new Sidebar.MenuItem { Title = "Пароль", Url = "/profile/change-password" }
-            }
-        },
-        new Sidebar.MenuGroup
-        {
-            Title = "AI",
-            Items = new()
-            {
-                new Sidebar.MenuItem { Title = "AI Agent", Url = "/agent" }
-            }
-        }
-    };
 
     private async Task Logout()
     {

--- a/Client.Wasm/Client.Wasm/Program.cs
+++ b/Client.Wasm/Client.Wasm/Program.cs
@@ -47,6 +47,7 @@ builder.Services.AddAuthorizationCore();
 builder.Services.AddScoped<CustomAuthStateProvider>();
 builder.Services.AddScoped<AuthenticationStateProvider>(sp => sp.GetRequiredService<CustomAuthStateProvider>());
 builder.Services.AddScoped<IAuthService, AuthService>();
+builder.Services.AddSingleton<MenuService>();
 
 var assembly = typeof(Program).Assembly;
 var clients = assembly.GetTypes().Where(t => t.IsClass && !t.IsAbstract && t.Name.EndsWith("ApiClient"));

--- a/Client.Wasm/Client.Wasm/Services/MenuService.cs
+++ b/Client.Wasm/Client.Wasm/Services/MenuService.cs
@@ -1,0 +1,91 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
+
+namespace Client.Wasm.Services;
+
+public class MenuService
+{
+    public List<MenuGroup> Groups { get; } = new();
+
+    public MenuService()
+    {
+        BuildMenu();
+    }
+
+    private void BuildMenu()
+    {
+        var pages = typeof(Program).Assembly
+            .GetTypes()
+            .Where(t => typeof(ComponentBase).IsAssignableFrom(t))
+            .SelectMany(t => t.GetCustomAttributes<RouteAttribute>(), (t, attr) => (Route: attr.Template, Type: t))
+            .Distinct()
+            .ToList();
+
+        Console.WriteLine($"Found pages: {string.Join(", ", pages.Select(p => p.Route))}");
+
+        var groupStatements = new MenuGroup { Title = "📄 Заявления" };
+        AddIfExists(pages, groupStatements.Items, "/applications", "Заявления");
+        AddIfExists(pages, groupStatements.Items, "/registry/applications", "Реестр заявлений");
+        AddIfExists(pages, groupStatements.Items, "/registry/rdz-orders", "Распоряжения РДЗ");
+        AddIfExists(pages, groupStatements.Items, "/registry/rdi-orders", "Распоряжения РДИ");
+        if (groupStatements.Items.Count > 0) Groups.Add(groupStatements);
+
+        var groupDocs = new MenuGroup { Title = "📑 Документы" };
+        AddIfExists(pages, groupDocs.Items, "/registry/contracts", "Договоры");
+        AddIfExists(pages, groupDocs.Items, "/registry/acts", "Акты");
+        AddIfExists(pages, groupDocs.Items, "/registry/agreements", "Соглашения");
+        AddIfExists(pages, groupDocs.Items, "/registry/answers", "Ответы");
+        if (groupDocs.Items.Count > 0) Groups.Add(groupDocs);
+
+        var groupUsers = new MenuGroup { Title = "👤 Пользователи и роли" };
+        AddIfExists(pages, groupUsers.Items, "/users", "Пользователи");
+        AddIfExists(pages, groupUsers.Items, "/permission-groups", "Группы прав");
+        if (groupUsers.Items.Count > 0) Groups.Add(groupUsers);
+
+        var groupSettings = new MenuGroup { Title = "⚙️ Настройки" };
+        AddIfExists(pages, groupSettings.Items, "/services", "Сервисы");
+        AddIfExists(pages, groupSettings.Items, "/service-templates", "Шаблоны услуг");
+        AddIfExists(pages, groupSettings.Items, "/workflows", "Рабочие процессы");
+        AddIfExists(pages, groupSettings.Items, "/document-templates", "Шаблоны документов");
+        AddIfExists(pages, groupSettings.Items, "/number-templates", "Шаблоны номеров");
+        AddIfExists(pages, groupSettings.Items, "/dictionaries", "Справочники");
+        if (groupSettings.Items.Count > 0) Groups.Add(groupSettings);
+
+        var groupReports = new MenuGroup { Title = "📊 Отчёты" };
+        AddIfExists(pages, groupReports.Items, "/dashboard", "Дашборд");
+        if (groupReports.Items.Count > 0) Groups.Add(groupReports);
+
+        var groupAi = new MenuGroup { Title = "AI" };
+        AddIfExists(pages, groupAi.Items, "/agent", "AI Agent");
+        if (groupAi.Items.Count > 0) Groups.Add(groupAi);
+
+        Console.WriteLine($"Created menu: {string.Join(" | ", Groups.Select(g => g.Title + ":" + string.Join(',', g.Items.Select(i => i.Title)) ))}");
+
+        var missing = pages.Where(p => !Groups.SelectMany(g => g.Items).Any(i => i.Url == p.Route) && !p.Route.Contains("{")).Select(p => p.Route).ToList();
+        if (missing.Any())
+        {
+            Console.WriteLine($"Warning: pages not added to menu: {string.Join(", ", missing)}");
+        }
+    }
+
+    private static void AddIfExists(List<(string Route, Type Type)> pages, List<MenuItem> items, string route, string title)
+    {
+        if (pages.Any(p => p.Route == route))
+        {
+            items.Add(new MenuItem { Title = title, Url = route });
+        }
+    }
+
+    public class MenuGroup
+    {
+        public string Title { get; set; } = string.Empty;
+        public List<MenuItem> Items { get; set; } = new();
+    }
+
+    public class MenuItem
+    {
+        public string Title { get; set; } = string.Empty;
+        public string Url { get; set; } = string.Empty;
+    }
+}

--- a/Client.Wasm/Client.Wasm/wwwroot/css/site.css
+++ b/Client.Wasm/Client.Wasm/wwwroot/css/site.css
@@ -106,3 +106,32 @@ html, body {
     from { opacity: 0; transform: translateY(10px); }
     to { opacity: 1; transform: translateY(0); }
 }
+
+.sidebar-menu .e-acrdn-item {
+    border: none;
+}
+
+.sidebar-menu .e-acrdn-header {
+    padding: 0.75rem 1rem;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.sidebar-menu .e-acrdn-panel {
+    padding: 0;
+}
+
+.sidebar-menu .nav-link {
+    display: block;
+    padding: 0.5rem 1.25rem;
+    border-radius: var(--radius);
+    color: #1f2937;
+    transition: background-color 0.2s, transform 0.2s;
+}
+
+.sidebar-menu .nav-link.active,
+.sidebar-menu .nav-link:hover {
+    background-color: rgba(37, 99, 235, 0.1);
+    color: #2563eb;
+    transform: scale(1.02);
+}


### PR DESCRIPTION
## Summary
- add `MenuService` that scans page routes and builds groups automatically
- update `Sidebar` to render groups from `MenuService`
- simplify `MainLayout` sidebar integration
- register `MenuService` in `Program.cs`
- refine sidebar styles for light theme

## Testing
- `dotnet build Client.Wasm/Client.Wasm/Client.Wasm.csproj -c Release`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685402caaddc83238379eceaa3e4367d