### PR TITLE
Fix sidebar accordion init

### DIFF
--- a/Client.Wasm/Client.Wasm/Services/MenuService.cs
+++ b/Client.Wasm/Client.Wasm/Services/MenuService.cs
@@ -67,6 +67,34 @@ public class MenuService
         {
             Console.WriteLine($"Warning: pages not added to menu: {string.Join(", ", missing)}");
         }
+
+        if (Groups.Count == 0)
+        {
+            Groups.Add(new MenuGroup
+            {
+                Title = "Заявления",
+                Items = new List<MenuItem>
+                {
+                    new() { Title = "Список заявлений", Url = "/applications" }
+                }
+            });
+            Groups.Add(new MenuGroup
+            {
+                Title = "Документы",
+                Items = new List<MenuItem>
+                {
+                    new() { Title = "Список документов", Url = "/documents" }
+                }
+            });
+            Groups.Add(new MenuGroup
+            {
+                Title = "Настройки",
+                Items = new List<MenuItem>
+                {
+                    new() { Title = "Общие", Url = "/settings" }
+                }
+            });
+        }
     }
 
     private static void AddIfExists(List<(string Route, Type Type)> pages, List<MenuItem> items, string route, string title)

--- a/Client.Wasm/Client.Wasm/wwwroot/js/file.js
+++ b/Client.Wasm/Client.Wasm/wwwroot/js/file.js
@@ -36,10 +36,16 @@ window.signWithCryptoPro = async (base64) => {
 };
 
 window.checkAccordionInit = () => {
-    const acc = document.querySelector('.e-accordion');
-    if (!acc) {
-        console.error('❌ Accordion menu not initialized');
+    const accEl = document.querySelector('.e-sidebar .e-accordion');
+    if (!accEl) {
+        console.error('❌ Accordion element not found');
+        return;
+    }
+    const accObj = accEl.ej2_instances && accEl.ej2_instances[0];
+    if (!accObj) {
+        console.error('❌ Accordion instance not initialized');
     } else {
-        console.log('✅ Меню успешно инициализировано и работает');
+        console.log('✅ Меню успешно инициализировано');
+        accObj.refresh();
     }
 };


### PR DESCRIPTION
## Summary
- add fallback sidebar menu data in case no pages were found
- ensure `checkAccordionInit` validates and refreshes the accordion instance

## Testing
- `dotnet build GovServicesSolution.sln -clp:ErrorsOnly`
- `dotnet test Server.Tests/Server.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6854086cf9ec83238c30e275cbc689c8