### PR TITLE
Fix tab header markup

### DIFF
--- a/Client.Wasm/Client.Wasm/Components/ExternalRequestsTabs.razor
+++ b/Client.Wasm/Client.Wasm/Components/ExternalRequestsTabs.razor
@@ -8,7 +8,10 @@
     <SfCard CssClass="rounded-xl shadow-lg glass-effect mb-4 p-6">
         <SfTab>
             <TabItems>
-                <TabItem HeaderText="Росреестр">
+                <TabItem>
+                    <ChildContent>
+                        <TabHeader Text="Росреестр"></TabHeader>
+                    </ChildContent>
                     <ContentTemplate>
                         <SfButton CssClass="e-outline mb-3" OnClick="CreateRosreestr">Создать запрос</SfButton>
                         <SfGrid DataSource="rosreestr" AllowPaging="true" CssClass="e-bootstrap5">
@@ -20,7 +23,10 @@
                         </SfGrid>
                     </ContentTemplate>
                 </TabItem>
-                <TabItem HeaderText="ЗАГС">
+                <TabItem>
+                    <ChildContent>
+                        <TabHeader Text="ЗАГС"></TabHeader>
+                    </ChildContent>
                     <ContentTemplate>
                         <SfButton CssClass="e-outline mb-3" OnClick="CreateZags">Создать запрос</SfButton>
                         <SfGrid DataSource="zags" AllowPaging="true" CssClass="e-bootstrap5">

--- a/Client.Wasm/Client.Wasm/Components/RelatedApplicationsTabs.razor
+++ b/Client.Wasm/Client.Wasm/Components/RelatedApplicationsTabs.razor
@@ -8,7 +8,10 @@
     <SfCard CssClass="rounded-xl shadow-lg glass-effect mb-4 p-6">
         <SfTab>
             <TabItems>
-                <TabItem HeaderText="Другие заявления заявителя">
+                <TabItem>
+                    <ChildContent>
+                        <TabHeader Text="Другие заявления заявителя"></TabHeader>
+                    </ChildContent>
                     <ContentTemplate>
                         <SfGrid DataSource="@byApplicant" AllowPaging="true" RowSelected="OnRowSelected" CssClass="e-bootstrap5">
                             <GridPageSettings PageSize="5" />
@@ -20,7 +23,10 @@
                         </SfGrid>
                     </ContentTemplate>
                 </TabItem>
-                <TabItem HeaderText="Заявления с этим представителем">
+                <TabItem>
+                    <ChildContent>
+                        <TabHeader Text="Заявления с этим представителем"></TabHeader>
+                    </ChildContent>
                     <ContentTemplate>
                         <SfGrid DataSource="@byRepresentative" AllowPaging="true" RowSelected="OnRowSelected" CssClass="e-bootstrap5">
                             <GridPageSettings PageSize="5" />
@@ -32,7 +38,10 @@
                         </SfGrid>
                     </ContentTemplate>
                 </TabItem>
-                <TabItem HeaderText="По пересечению координат">
+                <TabItem>
+                    <ChildContent>
+                        <TabHeader Text="По пересечению координат"></TabHeader>
+                    </ChildContent>
                     <ContentTemplate>
                         <SfGrid DataSource="@byGeo" AllowPaging="true" RowSelected="OnRowSelected" CssClass="e-bootstrap5">
                             <GridPageSettings PageSize="5" />


### PR DESCRIPTION
## Summary
- update tab markup to use `TabHeader` instead of the removed `HeaderText`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68554673f5108323a0cc14401c6a2354