### PR TITLE
Fix Syncfusion asset paths

### DIFF
--- a/Client.Wasm/Client.Wasm/wwwroot/index.html
+++ b/Client.Wasm/Client.Wasm/wwwroot/index.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Client.Wasm</title>
     <base href="/" />
-    <link href="_content/Syncfusion.Blazor/styles/bootstrap5.css" rel="stylesheet" />
-    <link href="_content/Syncfusion.Blazor/styles/material.css" rel="stylesheet" />
+    <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
+    <link href="_content/Syncfusion.Blazor.Themes/material.css" rel="stylesheet" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- fix paths to Syncfusion CSS assets in `index.html`
- verified build and tests

## Testing
- `dotnet build GovServicesSolution.sln`
- `dotnet test GovServicesSolution.sln`


------
https://chatgpt.com/codex/tasks/task_e_68554e11c8b8832388ca43de48a76f6f