### PR TITLE
Fix orientation ambiguity in Blazor project

### DIFF
--- a/Client.Wasm/Client.Wasm/Components/TopNav.razor
+++ b/Client.Wasm/Client.Wasm/Components/TopNav.razor
@@ -2,16 +2,18 @@
 @inject NavigationManager Nav
 @inject AuthenticationStateProvider AuthProvider
 @inject IAuthService AuthService
+@using LayoutOrientation = Syncfusion.Blazor.Layouts.Orientation
+@using ChartOrientation = Syncfusion.Blazor.Charts.Orientation
 
 <AuthorizeView>
     <Authorized>
-        <SfMenu Items="@MenuItems" CssClass="top-nav" HamburgerMode="true" Orientation="Orientation.Horizontal" ItemSelected="OnMenuItemSelected"></SfMenu>
+        <SfMenu Items="@MenuItems" CssClass="top-nav" HamburgerMode="true" Orientation="Syncfusion.Blazor.Navigations.Orientation.Horizontal" ItemSelected="OnMenuItemSelected"></SfMenu>
         <div class="user-dropdown">
             <SfDropDownButton CssClass="e-flat" IconCss="user-icon" Items="UserItems" ItemSelected="OnUserItemSelected"></SfDropDownButton>
         </div>
     </Authorized>
     <NotAuthorized>
-        <SfButton CssClass="e-primary" OnClick="()=>Nav.NavigateTo(\"/login\")">Войти</SfButton>
+        <SfButton CssClass="e-primary" OnClick="@(() => Nav.NavigateTo("/login"))">Войти</SfButton>
     </NotAuthorized>
 </AuthorizeView>
 

--- a/Client.Wasm/Client.Wasm/wwwroot/index.html
+++ b/Client.Wasm/Client.Wasm/wwwroot/index.html
@@ -39,7 +39,7 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
-    <script src="_content/Syncfusion.Blazor/scripts/syncfusion-blazor.min.js"></script>
+    <script src="_content/Syncfusion.Blazor.Core/scripts/syncfusion-blazor.min.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- alias LayoutOrientation and ChartOrientation in TopNav
- fully qualify menu orientation to avoid ambiguity
- fix `SfButton` onclick syntax
- load Syncfusion script from Core package

## Testing
- `dotnet build Client.Wasm/Client.Wasm/Client.Wasm.csproj -c Release`
- `dotnet build Server.Api/Server.Api/Server.Api.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_685554a4e47c8323bf76c50679fb693b