### PR TITLE
Add role dashboards

### DIFF
--- a/Client.Wasm/Client.Wasm/Pages/Dashboards/DepartmentHeadDashboard.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Dashboards/DepartmentHeadDashboard.razor
@@ -1,0 +1,60 @@
+@page "/dashboard/department"
+@attribute [Authorize(Roles="Начальник отдела")]
+@using Syncfusion.Blazor.Charts
+@inject NavigationManager Nav
+
+<div class="container p-4">
+    <h1 class="mb-4">Дашборд начальника отдела</h1>
+    <div class="row g-4">
+        <div class="col-md-4 col-sm-6">
+            <SfCard CssClass="rounded-xl shadow-lg glass-effect p-6 text-center">
+                <CardHeader><h4>Активные заявления</h4></CardHeader>
+                <CardContent><h2 class="display-6">@activeApps</h2></CardContent>
+            </SfCard>
+        </div>
+        <div class="col-md-4 col-sm-6">
+            <SfCard CssClass="rounded-xl shadow-lg glass-effect p-6 text-center">
+                <CardHeader><h4>Сотрудники</h4></CardHeader>
+                <CardContent><h2 class="display-6">@employees</h2></CardContent>
+            </SfCard>
+        </div>
+        <div class="col-md-4 col-sm-6">
+            <SfCard CssClass="rounded-xl shadow-lg glass-effect p-6 text-center">
+                <CardHeader><h4>Просроченные</h4></CardHeader>
+                <CardContent><h2 class="display-6">@overdue</h2></CardContent>
+            </SfCard>
+        </div>
+    </div>
+
+    <div class="row g-4 mt-4">
+        <div class="col-12">
+            <SfChart Title="Заявления по специалистам" PointClick="OnPointClick">
+                <ChartPrimaryXAxis ValueType="Syncfusion.Blazor.Charts.ValueType.Category"></ChartPrimaryXAxis>
+                <ChartSeriesCollection>
+                    <ChartSeries DataSource="appsByUser" XName="User" YName="Count" Type="ChartSeriesType.Column"></ChartSeries>
+                </ChartSeriesCollection>
+            </SfChart>
+        </div>
+    </div>
+</div>
+
+@code {
+    int activeApps = 42;
+    int employees = 6;
+    int overdue = 3;
+
+    List<UserCount> appsByUser = new()
+    {
+        new UserCount("Иванов", 10),
+        new UserCount("Петров", 15),
+        new UserCount("Сидоров", 17)
+    };
+
+    void OnPointClick(PointEventArgs args)
+    {
+        var item = appsByUser[args.Point.Index];
+        Nav.NavigateTo($"/applications?user={item.User}");
+    }
+
+    record UserCount(string User, int Count);
+}

--- a/Client.Wasm/Client.Wasm/Pages/Dashboards/DirectorDashboard.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Dashboards/DirectorDashboard.razor
@@ -1,0 +1,60 @@
+@page "/dashboard/director"
+@attribute [Authorize(Roles="Директор")]
+@using Syncfusion.Blazor.Charts
+@inject NavigationManager Nav
+
+<div class="container p-4">
+    <h1 class="mb-4">Дашборд директора</h1>
+    <div class="row g-4">
+        <div class="col-md-4 col-sm-6">
+            <SfCard CssClass="rounded-xl shadow-lg glass-effect p-6 text-center">
+                <CardHeader><h4>Всего заявлений</h4></CardHeader>
+                <CardContent><h2 class="display-6">@total</h2></CardContent>
+            </SfCard>
+        </div>
+        <div class="col-md-4 col-sm-6">
+            <SfCard CssClass="rounded-xl shadow-lg glass-effect p-6 text-center">
+                <CardHeader><h4>Среднее время</h4></CardHeader>
+                <CardContent><h2 class="display-6">@avg ч.</h2></CardContent>
+            </SfCard>
+        </div>
+        <div class="col-md-4 col-sm-6">
+            <SfCard CssClass="rounded-xl shadow-lg glass-effect p-6 text-center">
+                <CardHeader><h4>Активные распоряжения</h4></CardHeader>
+                <CardContent><h2 class="display-6">@orders</h2></CardContent>
+            </SfCard>
+        </div>
+    </div>
+
+    <div class="row g-4 mt-4">
+        <div class="col-lg-12">
+            <SfChart Title="Заявления по подразделениям" PointClick="OnDeptClick">
+                <ChartPrimaryXAxis ValueType="Syncfusion.Blazor.Charts.ValueType.Category"></ChartPrimaryXAxis>
+                <ChartSeriesCollection>
+                    <ChartSeries DataSource="appsByDept" XName="Dept" YName="Count" Type="ChartSeriesType.Column"></ChartSeries>
+                </ChartSeriesCollection>
+            </SfChart>
+        </div>
+    </div>
+</div>
+
+@code {
+    int total = 320;
+    double avg = 2.7;
+    int orders = 14;
+
+    List<DeptCount> appsByDept = new()
+    {
+        new DeptCount("Отдел 1", 80),
+        new DeptCount("Отдел 2", 100),
+        new DeptCount("Отдел 3", 140)
+    };
+
+    void OnDeptClick(PointEventArgs args)
+    {
+        var item = appsByDept[args.Point.Index];
+        Nav.NavigateTo($"/dashboard/department?dept={item.Dept}");
+    }
+
+    record DeptCount(string Dept, int Count);
+}

--- a/Client.Wasm/Client.Wasm/Pages/Dashboards/ManagementHeadDashboard.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Dashboards/ManagementHeadDashboard.razor
@@ -1,0 +1,90 @@
+@page "/dashboard/management"
+@attribute [Authorize(Roles="Начальник управления")]
+@using Syncfusion.Blazor.Charts
+@inject NavigationManager Nav
+
+<div class="container p-4">
+    <h1 class="mb-4">Дашборд начальника управления</h1>
+    <div class="row g-4">
+        <div class="col-md-3 col-6">
+            <SfCard CssClass="rounded-xl shadow-lg glass-effect p-6 text-center">
+                <CardHeader><h4>Всего заявлений</h4></CardHeader>
+                <CardContent><h2 class="display-6">@totalApps</h2></CardContent>
+            </SfCard>
+        </div>
+        <div class="col-md-3 col-6">
+            <SfCard CssClass="rounded-xl shadow-lg glass-effect p-6 text-center">
+                <CardHeader><h4>В работе</h4></CardHeader>
+                <CardContent><h2 class="display-6">@inProgress</h2></CardContent>
+            </SfCard>
+        </div>
+        <div class="col-md-3 col-6">
+            <SfCard CssClass="rounded-xl shadow-lg glass-effect p-6 text-center">
+                <CardHeader><h4>Ожидают подписи</h4></CardHeader>
+                <CardContent><h2 class="display-6">@pendingSign</h2></CardContent>
+            </SfCard>
+        </div>
+        <div class="col-md-3 col-6">
+            <SfCard CssClass="rounded-xl shadow-lg glass-effect p-6 text-center">
+                <CardHeader><h4>Сотрудники</h4></CardHeader>
+                <CardContent><h2 class="display-6">@people</h2></CardContent>
+            </SfCard>
+        </div>
+    </div>
+
+    <div class="row g-4 mt-4">
+        <div class="col-lg-6">
+            <SfAccumulationChart Title="Распределение заявлений" PointClick="OnAppClick">
+                <AccumulationChartSeriesCollection>
+                    <AccumulationChartSeries DataSource="appDistribution" XName="Status" YName="Count" Type="AccumulationType.Pie" DataLabelSettings-Visible="true"></AccumulationChartSeries>
+                </AccumulationChartSeriesCollection>
+            </SfAccumulationChart>
+        </div>
+        <div class="col-lg-6">
+            <SfChart Title="Заявления по дням" PointClick="OnDayClick">
+                <ChartPrimaryXAxis ValueType="Syncfusion.Blazor.Charts.ValueType.Category"></ChartPrimaryXAxis>
+                <ChartSeriesCollection>
+                    <ChartSeries DataSource="appsByDay" XName="Day" YName="Count" Type="ChartSeriesType.Line" Marker-Visible="true"></ChartSeries>
+                </ChartSeriesCollection>
+            </SfChart>
+        </div>
+    </div>
+</div>
+
+@code {
+    int totalApps = 75;
+    int inProgress = 28;
+    int pendingSign = 11;
+    int people = 14;
+
+    List<StatusCount> appDistribution = new()
+    {
+        new StatusCount("Новые", 20),
+        new StatusCount("В работе", 28),
+        new StatusCount("Закрыты", 27)
+    };
+
+    List<DayCount> appsByDay = new()
+    {
+        new DayCount("Пн", 10),
+        new DayCount("Вт", 12),
+        new DayCount("Ср", 15),
+        new DayCount("Чт", 18),
+        new DayCount("Пт", 20)
+    };
+
+    void OnAppClick(PointEventArgs args)
+    {
+        var item = appDistribution[args.Point.Index];
+        Nav.NavigateTo($"/applications?status={item.Status}");
+    }
+
+    void OnDayClick(PointEventArgs args)
+    {
+        var item = appsByDay[args.Point.Index];
+        Nav.NavigateTo($"/applications?day={item.Day}");
+    }
+
+    record StatusCount(string Status, int Count);
+    record DayCount(string Day, int Count);
+}

--- a/Client.Wasm/Client.Wasm/Pages/Dashboards/SpecialistDashboard.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Dashboards/SpecialistDashboard.razor
@@ -1,0 +1,92 @@
+@page "/dashboard/specialist"
+@attribute [Authorize(Roles="Исполнитель")]
+@using Syncfusion.Blazor.Charts
+@using Syncfusion.Blazor.Grids
+@inject NavigationManager Nav
+
+<div class="container p-4">
+    <h1 class="mb-4">Дашборд специалиста</h1>
+    <div class="row g-4">
+        <div class="col-md-3 col-6">
+            <SfCard CssClass="rounded-xl shadow-lg glass-effect p-6 text-center">
+                <CardHeader><h4>Заявления</h4></CardHeader>
+                <CardContent><h2 class="display-6">@applications</h2></CardContent>
+            </SfCard>
+        </div>
+        <div class="col-md-3 col-6">
+            <SfCard CssClass="rounded-xl shadow-lg glass-effect p-6 text-center">
+                <CardHeader><h4>Документы</h4></CardHeader>
+                <CardContent><h2 class="display-6">@documents</h2></CardContent>
+            </SfCard>
+        </div>
+        <div class="col-md-3 col-6">
+            <SfCard CssClass="rounded-xl shadow-lg glass-effect p-6 text-center">
+                <CardHeader><h4>Распоряжения</h4></CardHeader>
+                <CardContent><h2 class="display-6">@orders</h2></CardContent>
+            </SfCard>
+        </div>
+        <div class="col-md-3 col-6">
+            <SfCard CssClass="rounded-xl shadow-lg glass-effect p-6 text-center">
+                <CardHeader><h4>Среднее время</h4></CardHeader>
+                <CardContent><h2 class="display-6">@avgTime ч.</h2></CardContent>
+            </SfCard>
+        </div>
+    </div>
+
+    <div class="row g-4 mt-4">
+        <div class="col-lg-6">
+            <SfChart @ref="appChart" Title="Заявления по месяцам" PointClick="OnAppPointClick">
+                <ChartPrimaryXAxis ValueType="Syncfusion.Blazor.Charts.ValueType.Category"></ChartPrimaryXAxis>
+                <ChartSeriesCollection>
+                    <ChartSeries DataSource="appByMonth" Type="ChartSeriesType.Column" XName="Month" YName="Count"></ChartSeries>
+                </ChartSeriesCollection>
+            </SfChart>
+        </div>
+        <div class="col-lg-6">
+            <SfAccumulationChart Title="Документы по статусу" PointClick="OnDocPointClick">
+                <AccumulationChartSeriesCollection>
+                    <AccumulationChartSeries DataSource="docsByStatus" XName="Status" YName="Count" Type="AccumulationType.Pie" DataLabelSettings-Visible="true"></AccumulationChartSeries>
+                </AccumulationChartSeriesCollection>
+            </SfAccumulationChart>
+        </div>
+    </div>
+</div>
+
+@code {
+    int applications = 24;
+    int documents = 17;
+    int orders = 5;
+    double avgTime = 2.3;
+
+    SfChart? appChart;
+
+    List<MonthlyCount> appByMonth = new()
+    {
+        new MonthlyCount("Янв", 3),
+        new MonthlyCount("Фев", 5),
+        new MonthlyCount("Мар", 7),
+        new MonthlyCount("Апр", 9)
+    };
+
+    List<StatusCount> docsByStatus = new()
+    {
+        new StatusCount("На подпись", 6),
+        new StatusCount("Готово", 8),
+        new StatusCount("Черновик", 3)
+    };
+
+    void OnAppPointClick(PointEventArgs args)
+    {
+        var item = appByMonth[args.Point.Index];
+        Nav.NavigateTo($"/applications?month={item.Month}");
+    }
+
+    void OnDocPointClick(PointEventArgs args)
+    {
+        var item = docsByStatus[args.Point.Index];
+        Nav.NavigateTo($"/documents?status={item.Status}");
+    }
+
+    record MonthlyCount(string Month, int Count);
+    record StatusCount(string Status, int Count);
+}

--- a/Client.Wasm/Client.Wasm/Services/MenuService.cs
+++ b/Client.Wasm/Client.Wasm/Services/MenuService.cs
@@ -53,7 +53,11 @@ public class MenuService
         if (groupSettings.Items.Count > 0) Groups.Add(groupSettings);
 
         var groupReports = new MenuGroup { Title = "📊 Отчёты" };
-        AddIfExists(pages, groupReports.Items, "/dashboard", "Дашборд");
+        AddIfExists(pages, groupReports.Items, "/dashboard", "Общий дашборд");
+        AddIfExists(pages, groupReports.Items, "/dashboard/specialist", "Специалист");
+        AddIfExists(pages, groupReports.Items, "/dashboard/department", "Отдел");
+        AddIfExists(pages, groupReports.Items, "/dashboard/management", "Управление");
+        AddIfExists(pages, groupReports.Items, "/dashboard/director", "Директор");
         if (groupReports.Items.Count > 0) Groups.Add(groupReports);
 
         var groupAi = new MenuGroup { Title = "AI" };


### PR DESCRIPTION
## Summary
- add role-based dashboards for specialist, department head, management head and director
- extend menu to include new dashboard pages

## Testing
- `dotnet build GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_68590d1948a48323a99116b8c68f83bf