### PR TITLE
Add service deadline tracking

### DIFF
--- a/Client.Wasm/Client.Wasm/DTOs/CreateServiceDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/CreateServiceDto.cs
@@ -4,5 +4,9 @@ namespace Client.Wasm.DTOs
     {
         public string Name { get; set; }
         public string Description { get; set; }
+        public int? ExecutionDeadlineDays { get; set; }
+        public DateTime? ExecutionDeadlineDate { get; set; }
+        public List<ExecutionStage>? ExecutionStages { get; set; }
+        public string Status { get; set; } = "В процессе";
     }
 }

--- a/Client.Wasm/Client.Wasm/DTOs/ExecutionStage.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/ExecutionStage.cs
@@ -1,0 +1,8 @@
+namespace Client.Wasm.DTOs;
+
+public class ExecutionStage
+{
+    public string Name { get; set; } = string.Empty;
+    public int Days { get; set; }
+    public string? ConditionJson { get; set; }
+}

--- a/Client.Wasm/Client.Wasm/DTOs/ServiceDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/ServiceDto.cs
@@ -5,6 +5,10 @@ namespace Client.Wasm.DTOs
         public int Id { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
+        public int? ExecutionDeadlineDays { get; set; }
+        public DateTime? ExecutionDeadlineDate { get; set; }
+        public List<ExecutionStage>? ExecutionStages { get; set; }
+        public string Status { get; set; } = "В процессе";
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
     }

--- a/Client.Wasm/Client.Wasm/DTOs/UpdateServiceDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/UpdateServiceDto.cs
@@ -4,5 +4,9 @@ namespace Client.Wasm.DTOs
     {
         public string Name { get; set; }
         public string Description { get; set; }
+        public int? ExecutionDeadlineDays { get; set; }
+        public DateTime? ExecutionDeadlineDate { get; set; }
+        public List<ExecutionStage>? ExecutionStages { get; set; }
+        public string Status { get; set; } = "В процессе";
     }
 }

--- a/Client.Wasm/Client.Wasm/Pages/ServiceEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/ServiceEdit.razor
@@ -16,6 +16,8 @@
     <ContentTemplate>
                     <SfTextBox TValue="string" @bind-Value="model.Name" Placeholder="Название" CssClass="mb-3 w-100" />
                     <SfTextBox TValue="string" Multiline="true" @bind-Value="model.Description" Placeholder="Описание" CssClass="mb-3 w-100" Rows="3" />
+                    <SfNumericTextBox TValue="int?" @bind-Value="model.ExecutionDeadlineDays" Placeholder="Срок (дней)" CssClass="mb-3 w-100" />
+                    <SfDatePicker TValue="DateTime?" @bind-Value="model.ExecutionDeadlineDate" Placeholder="Точная дата" CssClass="mb-3 w-100" />
                 </ContentTemplate>
 </TabItem>
             </TabItems>
@@ -34,7 +36,15 @@
 
     public void Show(CreateServiceDto dto)
     {
-        model = new ServiceDto();
+        model = new ServiceDto
+        {
+            Name = dto.Name,
+            Description = dto.Description,
+            ExecutionDeadlineDays = dto.ExecutionDeadlineDays,
+            ExecutionDeadlineDate = dto.ExecutionDeadlineDate,
+            ExecutionStages = dto.ExecutionStages,
+            Status = dto.Status
+        };
         header = "Новая услуга";
         _ = dlg.ShowAsync();
     }
@@ -51,9 +61,25 @@
     async Task HandleSave()
     {
         if (model.Id == 0)
-            await ApiClient.CreateAsync(new CreateServiceDto { Name = model.Name, Description = model.Description });
+            await ApiClient.CreateAsync(new CreateServiceDto
+            {
+                Name = model.Name,
+                Description = model.Description,
+                ExecutionDeadlineDays = model.ExecutionDeadlineDays,
+                ExecutionDeadlineDate = model.ExecutionDeadlineDate,
+                ExecutionStages = model.ExecutionStages,
+                Status = model.Status
+            });
         else
-            await ApiClient.UpdateAsync(model.Id, new UpdateServiceDto { Name = model.Name, Description = model.Description });
+            await ApiClient.UpdateAsync(model.Id, new UpdateServiceDto
+            {
+                Name = model.Name,
+                Description = model.Description,
+                ExecutionDeadlineDays = model.ExecutionDeadlineDays,
+                ExecutionDeadlineDate = model.ExecutionDeadlineDate,
+                ExecutionStages = model.ExecutionStages,
+                Status = model.Status
+            });
         await dlg.HideAsync();
         if (OnSaved.HasDelegate)
         {

--- a/Client.Wasm/Client.Wasm/Pages/Services.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Services.razor
@@ -4,6 +4,7 @@
 @using Client.Wasm.DTOs
 @inject IJSRuntime Js
 @inject NavigationManager NavigationManager
+@using Syncfusion.Blazor.Grids
 
 <div class="container p-4">
     <SfCard CssClass="mb-4">
@@ -18,6 +19,9 @@
                 <GridColumn Field=@nameof(ServiceDto.Id) HeaderText="ID" Width="70" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
             <GridColumn Field=@nameof(ServiceDto.Name) HeaderText="Название" Width="200" />
             <GridColumn Field=@nameof(ServiceDto.Description) HeaderText="Описание" Width="200" />
+            <GridColumn Field=@nameof(ServiceDto.ExecutionDeadlineDays) HeaderText="Срок (дней)" Width="120" />
+            <GridColumn Field=@nameof(ServiceDto.ExecutionDeadlineDate) HeaderText="Дедлайн" Format="d" Width="120" />
+            <GridColumn Field=@nameof(ServiceDto.Status) HeaderText="Статус" Width="120" />
             <GridColumn Field=@nameof(ServiceDto.CreatedAt) HeaderText="Создана" Format="d" Width="120" />
             <GridColumn Field=@nameof(ServiceDto.UpdatedAt) HeaderText="Обновлена" Format="d" Width="120" />
             <GridColumn HeaderText="" Width="120" TextAlign="TextAlign.Center">
@@ -49,6 +53,7 @@
     void OpenNew() => editDialog.Show(new CreateServiceDto());
 
     void Edit(int id) => editDialog.Load(id);
+
 
     async Task Delete(int id)
     {

--- a/Server.Api/Server.Api/BackgroundServices/DeadlineMonitoringService.cs
+++ b/Server.Api/Server.Api/BackgroundServices/DeadlineMonitoringService.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.EntityFrameworkCore;
+using GovServices.Server.Data;
+using GovServices.Server.Entities;
+using GovServices.Server.Interfaces;
+using System.Text.Json;
+
+namespace GovServices.Server.BackgroundServices;
+
+public class DeadlineMonitoringService : BackgroundService
+{
+    private readonly IServiceProvider _services;
+    private readonly ILogger<DeadlineMonitoringService> _logger;
+    private readonly TimeSpan _interval = TimeSpan.FromHours(6);
+
+    public DeadlineMonitoringService(IServiceProvider services, ILogger<DeadlineMonitoringService> logger)
+    {
+        _services = services;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            using var scope = _services.CreateScope();
+            var ctx = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var email = scope.ServiceProvider.GetService<IEmailService>();
+
+            var services = await ctx.Services.ToListAsync(stoppingToken);
+            foreach (var service in services)
+            {
+                var due = service.ExecutionDeadlineDate ?? service.CreatedAt.AddDays(service.ExecutionDeadlineDays ?? 0);
+                var daysLeft = (due - DateTime.UtcNow).TotalDays;
+
+                if (daysLeft < 0 && service.Status != "Просрочено")
+                {
+                    service.Status = "Просрочено";
+                    if (email != null)
+                    {
+                        await email.SendEmailAsync("admin@example.com", $"Услуга {service.Name} просрочена", $"{service.Name} просрочена");
+                    }
+                }
+                else if (service.Status != "Просрочено")
+                {
+                    if (daysLeft <= 1)
+                    {
+                        _logger.LogInformation("Срок услуги {Name} истекает завтра", service.Name);
+                    }
+                    else if (daysLeft <= 3)
+                    {
+                        _logger.LogInformation("Срок услуги {Name} истекает через три дня", service.Name);
+                    }
+                }
+            }
+            await ctx.SaveChangesAsync(stoppingToken);
+            await Task.Delay(_interval, stoppingToken);
+        }
+    }
+}

--- a/Server.Api/Server.Api/DTOs/CreateServiceDto.cs
+++ b/Server.Api/Server.Api/DTOs/CreateServiceDto.cs
@@ -4,5 +4,9 @@ namespace GovServices.Server.DTOs
     {
         public string Name { get; set; }
         public string Description { get; set; }
+        public int? ExecutionDeadlineDays { get; set; }
+        public DateTime? ExecutionDeadlineDate { get; set; }
+        public List<ExecutionStage>? ExecutionStages { get; set; }
+        public string Status { get; set; } = "В процессе";
     }
 }

--- a/Server.Api/Server.Api/DTOs/ExecutionStage.cs
+++ b/Server.Api/Server.Api/DTOs/ExecutionStage.cs
@@ -1,0 +1,8 @@
+namespace GovServices.Server.DTOs;
+
+public class ExecutionStage
+{
+    public string Name { get; set; } = string.Empty;
+    public int Days { get; set; }
+    public string? ConditionJson { get; set; }
+}

--- a/Server.Api/Server.Api/DTOs/ServiceDto.cs
+++ b/Server.Api/Server.Api/DTOs/ServiceDto.cs
@@ -5,6 +5,10 @@ namespace GovServices.Server.DTOs
         public int Id { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
+        public int? ExecutionDeadlineDays { get; set; }
+        public DateTime? ExecutionDeadlineDate { get; set; }
+        public List<ExecutionStage>? ExecutionStages { get; set; }
+        public string Status { get; set; } = "В процессе";
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
     }

--- a/Server.Api/Server.Api/DTOs/UpdateServiceDto.cs
+++ b/Server.Api/Server.Api/DTOs/UpdateServiceDto.cs
@@ -4,5 +4,9 @@ namespace GovServices.Server.DTOs
     {
         public string Name { get; set; }
         public string Description { get; set; }
+        public int? ExecutionDeadlineDays { get; set; }
+        public DateTime? ExecutionDeadlineDate { get; set; }
+        public List<ExecutionStage>? ExecutionStages { get; set; }
+        public string Status { get; set; } = "В процессе";
     }
 }

--- a/Server.Api/Server.Api/Entities/Service.cs
+++ b/Server.Api/Server.Api/Entities/Service.cs
@@ -5,6 +5,10 @@ namespace GovServices.Server.Entities
         public int Id { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
+        public int? ExecutionDeadlineDays { get; set; }
+        public DateTime? ExecutionDeadlineDate { get; set; }
+        public string? ExecutionStagesJson { get; set; }
+        public string Status { get; set; } = "В процессе";
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
         public ICollection<Application> Applications { get; set; }

--- a/Server.Api/Server.Api/Mappings/MappingProfile.cs
+++ b/Server.Api/Server.Api/Mappings/MappingProfile.cs
@@ -6,6 +6,7 @@ using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
 using System.Linq;
 using System.Collections.Generic;
+using System.Text.Json;
 
 namespace GovServices.Server.Mappings
 {
@@ -71,9 +72,16 @@ namespace GovServices.Server.Mappings
                 .ForMember(d => d.Attachments, o => o.Ignore());
             CreateMap<CreateRosreestrRequestDto, RosreestrRequest>();
             CreateMap<SedDocumentLog, SedDocumentLogDto>().ReverseMap();
-            CreateMap<Service, ServiceDto>().ReverseMap();
-            CreateMap<CreateServiceDto, Service>();
-            CreateMap<UpdateServiceDto, Service>();
+            CreateMap<Service, ServiceDto>()
+                .ForMember(d => d.ExecutionStages, o => o.MapFrom(s => DeserializeStages(s.ExecutionStagesJson)))
+                .ReverseMap()
+                .ForMember(d => d.ExecutionStagesJson, o => o.MapFrom(s => SerializeStages(s.ExecutionStages)));
+
+            CreateMap<CreateServiceDto, Service>()
+                .ForMember(d => d.ExecutionStagesJson, o => o.MapFrom(s => SerializeStages(s.ExecutionStages)));
+
+            CreateMap<UpdateServiceDto, Service>()
+                .ForMember(d => d.ExecutionStagesJson, o => o.MapFrom(s => SerializeStages(s.ExecutionStages)));
             CreateMap<Template, TemplateDto>().ReverseMap();
             CreateMap<CreateTemplateDto, Template>();
             CreateMap<UpdateTemplateDto, Template>();
@@ -106,6 +114,18 @@ namespace GovServices.Server.Mappings
             CreateMap<UpdateServiceTemplateDto, ServiceTemplate>();
 
             CreateMap<Dictionary, DictionaryDto>();
+        }
+
+        private static List<ExecutionStage>? DeserializeStages(string? json)
+        {
+            return string.IsNullOrEmpty(json)
+                ? null
+                : JsonSerializer.Deserialize<List<ExecutionStage>>(json!);
+        }
+
+        private static string? SerializeStages(List<ExecutionStage>? stages)
+        {
+            return stages != null ? JsonSerializer.Serialize(stages) : null;
         }
     }
 }

--- a/Server.Api/Server.Api/Program.cs
+++ b/Server.Api/Server.Api/Program.cs
@@ -151,6 +151,7 @@ builder.Services.AddHostedService<ExampleBackgroundService>();
 builder.Services.AddHostedService<PasswordReminderService>();
 builder.Services.AddHostedService<StatusNotificationService>();
 builder.Services.AddHostedService<ExtractMonitoringService>();
+builder.Services.AddHostedService<DeadlineMonitoringService>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- store execution deadlines in Service DTOs
- monitor deadlines with new `DeadlineMonitoringService`
- display deadline columns in the services grid
- allow editing deadlines in service dialog

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6859101ac8b08323a7962ac5a1b28fd6