### PR TITLE
Remove old AspNetCore packages

### DIFF
--- a/Client.Wasm/Client.Wasm/Client.Wasm.csproj
+++ b/Client.Wasm/Client.Wasm/Client.Wasm.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.17" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Syncfusion.Blazor.Buttons" Version="29.2.11" />
     <PackageReference Include="Syncfusion.Blazor.Inputs" Version="29.2.11" />

--- a/Client.Wasm/Client.Wasm/DTOs/CreateDocumentDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/CreateDocumentDto.cs
@@ -1,9 +1,9 @@
-using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Components.Forms;
 namespace Client.Wasm.DTOs
 {
     public class CreateDocumentDto
     {
         public int ApplicationId { get; set; }
-        public IFormFile File { get; set; }
+        public IBrowserFile File { get; set; }
     }
 }

--- a/Client.Wasm/Client.Wasm/DTOs/CreateOutgoingDocumentDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/CreateOutgoingDocumentDto.cs
@@ -1,10 +1,10 @@
-using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Components.Forms;
 namespace Client.Wasm.DTOs
 {
     public class CreateOutgoingDocumentDto
     {
         public int ApplicationId { get; set; }
-        public IFormFile File { get; set; }
-        public List<IFormFile> Attachments { get; set; }
+        public IBrowserFile File { get; set; }
+        public List<IBrowserFile> Attachments { get; set; }
     }
 }

--- a/Client.Wasm/Client.Wasm/Properties/launchSettings.json
+++ b/Client.Wasm/Client.Wasm/Properties/launchSettings.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "$schema": "https://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,


### PR DESCRIPTION
## Summary
- drop obsolete `Microsoft.AspNetCore.Http.Abstractions` from the Blazor WASM project
- switch upload DTOs to use `IBrowserFile`
- update `launchSettings.json` schema link

## Testing
- `dotnet clean GovServicesSolution.sln`
- `dotnet restore GovServicesSolution.sln`
- `dotnet build GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_685920aaffd08323abecc44c45390f16