### PR TITLE
Fix SfMenu handlers

### DIFF
--- a/Client.Wasm/Client.Wasm/Components/TopNav.razor
+++ b/Client.Wasm/Client.Wasm/Components/TopNav.razor
@@ -7,7 +7,7 @@
 
 <AuthorizeView>
     <Authorized>
-        <SfMenu Items="@MenuItems" CssClass="top-nav" HamburgerMode="true" Orientation="Syncfusion.Blazor.Navigations.Orientation.Horizontal" OnItemSelected="OnMenuItemSelected"></SfMenu>
+        <SfMenu Items="@MenuItems" CssClass="top-nav" HamburgerMode="true" Orientation="Syncfusion.Blazor.Navigations.Orientation.Horizontal" MenuItemClicked="OnMenuItemClicked"></SfMenu>
         <div class="user-dropdown">
             <SfDropDownButton CssClass="e-flat" IconCss="user-icon" Items="UserItems" ItemSelected="OnUserItemSelected"></SfDropDownButton>
         </div>
@@ -35,8 +35,9 @@
         }).ToList();
     }
 
-    private void OnMenuItemSelected(MenuEventArgs<MenuItem> args)
+    private void OnMenuItemClicked(MenuEventArgs<MenuItem> args)
     {
+        Console.WriteLine(args.Item.Text);
         if (!string.IsNullOrEmpty(args.Item.Url))
         {
             Nav.NavigateTo(args.Item.Url);


### PR DESCRIPTION
## Summary
- switch SfMenu to use `MenuItemClicked`
- add handler `OnMenuItemClicked` that logs selection text

## Testing
- `dotnet build GovServicesSolution.sln`
- `dotnet test GovServicesSolution.sln`


------
https://chatgpt.com/codex/tasks/task_e_685924b90abc832383f3ac0e0a083ebf