### PR TITLE
Fix accordion init and load Syncfusion script

### DIFF
--- a/Client.Wasm/Client.Wasm/wwwroot/index.html
+++ b/Client.Wasm/Client.Wasm/wwwroot/index.html
@@ -39,7 +39,7 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
-    <script src="_content/Syncfusion.Blazor.Core/scripts/sf-blazor.min.js"></script>
+    <script src="_content/Syncfusion.Blazor.Core/scripts/syncfusion-blazor.min.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 

--- a/Client.Wasm/Client.Wasm/wwwroot/js/file.js
+++ b/Client.Wasm/Client.Wasm/wwwroot/js/file.js
@@ -36,16 +36,16 @@ window.signWithCryptoPro = async (base64) => {
 };
 
 
-window.checkAccordionInit = function() {
-    var acc = document.querySelector('.e-accordion');
-    if (acc && !acc.ej2_instances) {
-        try {
-            new ej.navigations.Accordion({}, acc);
-        } catch (e) {
-            console.error('Accordion init failed', e);
-        }
+function checkAccordionInit() {
+    if (typeof ej !== "undefined" && ej.base && typeof ej.base.enableRipple === "function") {
+        ej.base.enableRipple(true);
     }
-};
+
+    const element = document.querySelector(".e-accordion");
+    if (element && !element.ej2_instances) {
+        new ej.navigations.Accordion({}, element);
+    }
+}
 
 window.addEventListener('DOMContentLoaded', function(){
     if (window.checkAccordionInit) window.checkAccordionInit();


### PR DESCRIPTION
## Summary
- ensure `checkAccordionInit` initializes Syncfusion accordion and enables ripple
- load `syncfusion-blazor.min.js` instead of missing `sf-blazor.min.js`

## Testing
- `dotnet test`
- `curl -I http://localhost:5093/_content/Syncfusion.Blazor.Core/scripts/syncfusion-blazor.min.js`
- `curl -I http://localhost:5093/js/file.js`

------
https://chatgpt.com/codex/tasks/task_e_68592cb126b48323bf32fa2f58ad67e3