### PR TITLE
Refine Blazor layout with sticky header and main section

### DIFF
--- a/Client.Wasm/Client.Wasm/Components/TopNav.razor.css
+++ b/Client.Wasm/Client.Wasm/Components/TopNav.razor.css
@@ -1,6 +1,9 @@
 .appbar {
     background: #ffffff;
     border-bottom: 1px solid #e5e7eb;
+    position: sticky;
+    top: 0;
+    z-index: 50;
 }
 .profile-button {
     margin-left: 1rem;

--- a/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
+++ b/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
@@ -5,23 +5,26 @@
 @inject IJSRuntime JS
 
 <CascadingAuthenticationState>
-    @if (!Nav.Uri.Contains("/login"))
-    {
-        <TopNav />
-    }
+    <div class="min-h-screen flex flex-col">
+        @if (!Nav.Uri.Contains("/login"))
+        {
+            <header>
+                <TopNav />
+            </header>
+        }
 
+        <main class="flex-1 p-4 @(Nav.Uri.Contains("/login") ? "" : "container mx-auto")">
+            <RedirectToLogin />
+            @Body
+        </main>
 
-    <div class="content @(Nav.Uri.Contains("/login") ? "login-content" : "p-4")">
-        <RedirectToLogin />
-        @Body
+        @if (!Nav.Uri.Contains("/login"))
+        {
+            <footer class="bg-light text-center py-3 mt-auto">
+                &copy; 2025 Госуслуги
+            </footer>
+        }
     </div>
-
-    @if (!Nav.Uri.Contains("/login"))
-    {
-        <footer class="bg-light text-center py-3">
-            &copy; 2025 Госуслуги
-        </footer>
-    }
 </CascadingAuthenticationState>
 
 @code {


### PR DESCRIPTION
## Summary
- implement header/main/footer structure in `MainLayout`
- make header sticky via CSS
- ensure Flex layout for footer pinning

## Testing
- `dotnet build Client.Wasm/Client.Wasm/Client.Wasm.csproj -c Release`
- `dotnet run --project Client.Wasm/Client.Wasm/Client.Wasm.csproj` *(fails: terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_685948293968832398d13288558ce21e