### PR TITLE
Add user hierarchy models and pages

### DIFF
--- a/Client.Wasm/Client.Wasm/Client.Wasm.csproj
+++ b/Client.Wasm/Client.Wasm/Client.Wasm.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Syncfusion.Blazor.Layouts" Version="29.2.11" />
     <PackageReference Include="Syncfusion.Blazor.Charts" Version="29.2.11" />
     <PackageReference Include="Syncfusion.Blazor.Lists" Version="29.2.11" />
+    <PackageReference Include="Syncfusion.Blazor.TreeGrid" Version="29.2.11" />
     <PackageReference Include="Syncfusion.Blazor.FileManager" Version="29.2.11" />
     <PackageReference Include="Syncfusion.Blazor.WordProcessor" Version="29.2.11" />
     <PackageReference Include="Syncfusion.Blazor.Themes" Version="29.2.11" />

--- a/Client.Wasm/Client.Wasm/DTOs/DepartmentDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/DepartmentDto.cs
@@ -1,0 +1,9 @@
+namespace Client.Wasm.DTOs;
+
+public class DepartmentDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int? ParentDepartmentId { get; set; }
+    public string? Description { get; set; }
+}

--- a/Client.Wasm/Client.Wasm/DTOs/PermissionDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/PermissionDto.cs
@@ -1,0 +1,13 @@
+namespace Client.Wasm.DTOs;
+
+public class PermissionDto
+{
+    public int Id { get; set; }
+    public string Role { get; set; } = string.Empty;
+    public bool CanView { get; set; }
+    public bool CanEdit { get; set; }
+    public bool CanApprove { get; set; }
+    public bool CanDelete { get; set; }
+    public int ServiceId { get; set; }
+    public int DepartmentId { get; set; }
+}

--- a/Client.Wasm/Client.Wasm/DTOs/PositionDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/PositionDto.cs
@@ -1,0 +1,9 @@
+namespace Client.Wasm.DTOs;
+
+public class PositionDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int DepartmentId { get; set; }
+    public int StaffLimit { get; set; }
+}

--- a/Client.Wasm/Client.Wasm/DTOs/UserProfileDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/UserProfileDto.cs
@@ -1,0 +1,12 @@
+namespace Client.Wasm.DTOs;
+
+public class UserProfileDto
+{
+    public int Id { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public string FullName { get; set; } = string.Empty;
+    public int PositionId { get; set; }
+    public int DepartmentId { get; set; }
+    public bool IsActive { get; set; }
+    public int? SupervisorId { get; set; }
+}

--- a/Client.Wasm/Client.Wasm/Pages/DepartmentHierarchy.razor
+++ b/Client.Wasm/Client.Wasm/Pages/DepartmentHierarchy.razor
@@ -1,0 +1,27 @@
+@page "/departments"
+@inject IDepartmentApiClient ApiClient
+@using Client.Wasm.DTOs
+@using Syncfusion.Blazor.TreeGrid
+
+<SfCard CssClass="mb-4">
+    <CardHeader>
+        <h2>Подразделения</h2>
+    </CardHeader>
+    <CardContent>
+        <SfTreeGrid TValue="DepartmentDto" DataSource="@items" IdMapping="Id" ParentIdMapping="ParentDepartmentId" CssClass="e-bootstrap5">
+            <TreeGridColumns>
+                <TreeGridColumn Field="Name" HeaderText="Название" Width="250" />
+                <TreeGridColumn Field="Description" HeaderText="Описание" />
+            </TreeGridColumns>
+        </SfTreeGrid>
+    </CardContent>
+</SfCard>
+
+@code {
+    List<DepartmentDto> items = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        items = await ApiClient.GetAllAsync();
+    }
+}

--- a/Client.Wasm/Client.Wasm/Pages/Permissions.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Permissions.razor
@@ -1,0 +1,48 @@
+@page "/permissions"
+@inject IPermissionApiClient ApiClient
+@using Client.Wasm.DTOs
+@using Syncfusion.Blazor.Grids
+
+<SfCard CssClass="mb-4">
+    <CardHeader>
+        <h2>Права доступа</h2>
+    </CardHeader>
+    <CardContent>
+        <SfGrid TValue="PermissionDto" DataSource="@items" AllowPaging="true" CssClass="e-bootstrap5">
+            <GridColumns>
+                <GridColumn Field="Role" HeaderText="Роль" Width="150" />
+                <GridColumn Field="ServiceId" HeaderText="Услуга" Width="120" />
+                <GridColumn Field="DepartmentId" HeaderText="Отдел" Width="120" />
+                <GridColumn HeaderText="Просмотр" TextAlign="TextAlign.Center" Width="80">
+                    <Template>
+                        @((context as PermissionDto).CanView ? "✓" : "-")
+                    </Template>
+                </GridColumn>
+                <GridColumn HeaderText="Изменение" TextAlign="TextAlign.Center" Width="80">
+                    <Template>
+                        @((context as PermissionDto).CanEdit ? "✓" : "-")
+                    </Template>
+                </GridColumn>
+                <GridColumn HeaderText="Утверждение" TextAlign="TextAlign.Center" Width="80">
+                    <Template>
+                        @((context as PermissionDto).CanApprove ? "✓" : "-")
+                    </Template>
+                </GridColumn>
+                <GridColumn HeaderText="Удаление" TextAlign="TextAlign.Center" Width="80">
+                    <Template>
+                        @((context as PermissionDto).CanDelete ? "✓" : "-")
+                    </Template>
+                </GridColumn>
+            </GridColumns>
+        </SfGrid>
+    </CardContent>
+</SfCard>
+
+@code {
+    List<PermissionDto> items = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        items = await ApiClient.GetAllAsync();
+    }
+}

--- a/Client.Wasm/Client.Wasm/Pages/Positions.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Positions.razor
@@ -1,0 +1,28 @@
+@page "/positions"
+@inject IPositionApiClient ApiClient
+@using Client.Wasm.DTOs
+@using Syncfusion.Blazor.Grids
+
+<SfCard CssClass="mb-4">
+    <CardHeader>
+        <h2>Должности</h2>
+    </CardHeader>
+    <CardContent>
+        <SfGrid TValue="PositionDto" DataSource="@items" AllowPaging="true" CssClass="e-bootstrap5">
+            <GridColumns>
+                <GridColumn Field="Name" HeaderText="Название" Width="200" />
+                <GridColumn Field="DepartmentId" HeaderText="Отдел" Width="120" />
+                <GridColumn Field="StaffLimit" HeaderText="Штат" Width="100" />
+            </GridColumns>
+        </SfGrid>
+    </CardContent>
+</SfCard>
+
+@code {
+    List<PositionDto> items = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        items = await ApiClient.GetAllAsync();
+    }
+}

--- a/Client.Wasm/Client.Wasm/Services/DepartmentApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/DepartmentApiClient.cs
@@ -1,0 +1,26 @@
+namespace Client.Wasm.Services;
+
+using System.Net.Http.Json;
+using Client.Wasm.DTOs;
+using Client.Wasm.Helpers;
+
+public interface IDepartmentApiClient
+{
+    Task<List<DepartmentDto>> GetAllAsync();
+}
+
+public class DepartmentApiClient : IDepartmentApiClient
+{
+    private readonly HttpClient _http;
+
+    public DepartmentApiClient(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<List<DepartmentDto>> GetAllAsync()
+    {
+        var result = await _http.GetFromJsonSafeAsync<List<DepartmentDto>>("api/departments");
+        return result ?? new();
+    }
+}

--- a/Client.Wasm/Client.Wasm/Services/MenuService.cs
+++ b/Client.Wasm/Client.Wasm/Services/MenuService.cs
@@ -38,10 +38,19 @@ public class MenuService
         AddIfExists(pages, groupDocs.Items, "/registry/answers", "Ответы");
         if (groupDocs.Items.Count > 0) Groups.Add(groupDocs);
 
-        var groupUsers = new MenuGroup { Title = "👤 Пользователи и роли" };
+        var groupUsers = new MenuGroup { Title = "👤 Пользователи" };
         AddIfExists(pages, groupUsers.Items, "/users", "Пользователи");
-        AddIfExists(pages, groupUsers.Items, "/permission-groups", "Группы прав");
         if (groupUsers.Items.Count > 0) Groups.Add(groupUsers);
+
+        var groupStructure = new MenuGroup { Title = "🏢 Структура" };
+        AddIfExists(pages, groupStructure.Items, "/departments", "Подразделения");
+        AddIfExists(pages, groupStructure.Items, "/positions", "Должности");
+        if (groupStructure.Items.Count > 0) Groups.Add(groupStructure);
+
+        var groupRights = new MenuGroup { Title = "🔐 Права" };
+        AddIfExists(pages, groupRights.Items, "/permissions", "Права доступа");
+        AddIfExists(pages, groupRights.Items, "/permission-groups", "Группы прав");
+        if (groupRights.Items.Count > 0) Groups.Add(groupRights);
 
         var groupSettings = new MenuGroup { Title = "⚙️ Настройки" };
         AddIfExists(pages, groupSettings.Items, "/services", "Сервисы");

--- a/Client.Wasm/Client.Wasm/Services/PermissionApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/PermissionApiClient.cs
@@ -1,0 +1,26 @@
+namespace Client.Wasm.Services;
+
+using System.Net.Http.Json;
+using Client.Wasm.DTOs;
+using Client.Wasm.Helpers;
+
+public interface IPermissionApiClient
+{
+    Task<List<PermissionDto>> GetAllAsync();
+}
+
+public class PermissionApiClient : IPermissionApiClient
+{
+    private readonly HttpClient _http;
+
+    public PermissionApiClient(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<List<PermissionDto>> GetAllAsync()
+    {
+        var result = await _http.GetFromJsonSafeAsync<List<PermissionDto>>("api/permissions");
+        return result ?? new();
+    }
+}

--- a/Client.Wasm/Client.Wasm/Services/PositionApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/PositionApiClient.cs
@@ -1,0 +1,26 @@
+namespace Client.Wasm.Services;
+
+using System.Net.Http.Json;
+using Client.Wasm.DTOs;
+using Client.Wasm.Helpers;
+
+public interface IPositionApiClient
+{
+    Task<List<PositionDto>> GetAllAsync();
+}
+
+public class PositionApiClient : IPositionApiClient
+{
+    private readonly HttpClient _http;
+
+    public PositionApiClient(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<List<PositionDto>> GetAllAsync()
+    {
+        var result = await _http.GetFromJsonSafeAsync<List<PositionDto>>("api/positions");
+        return result ?? new();
+    }
+}

--- a/Client.Wasm/Client.Wasm/Services/UserProfileApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/UserProfileApiClient.cs
@@ -1,0 +1,26 @@
+namespace Client.Wasm.Services;
+
+using System.Net.Http.Json;
+using Client.Wasm.DTOs;
+using Client.Wasm.Helpers;
+
+public interface IUserProfileApiClient
+{
+    Task<List<UserProfileDto>> GetAllAsync();
+}
+
+public class UserProfileApiClient : IUserProfileApiClient
+{
+    private readonly HttpClient _http;
+
+    public UserProfileApiClient(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<List<UserProfileDto>> GetAllAsync()
+    {
+        var result = await _http.GetFromJsonSafeAsync<List<UserProfileDto>>("api/userprofiles");
+        return result ?? new();
+    }
+}

--- a/Client.Wasm/Client.Wasm/_Imports.razor
+++ b/Client.Wasm/Client.Wasm/_Imports.razor
@@ -28,6 +28,7 @@
 @using Syncfusion.Blazor.Calendars
 @using Syncfusion.Blazor.Charts
 @using Syncfusion.Blazor.Lists
+@using Syncfusion.Blazor.TreeGrid
 @using Syncfusion.Blazor.Notifications
 @using Syncfusion.Blazor.PdfViewer
 @using System.ComponentModel.DataAnnotations

--- a/Server.Api/Server.Api/Controllers/DepartmentsController.cs
+++ b/Server.Api/Server.Api/Controllers/DepartmentsController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+using GovServices.Server.DTOs;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class DepartmentsController : ControllerBase
+{
+    private readonly IDepartmentService _service;
+    public DepartmentsController(IDepartmentService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<DepartmentDto>>> Get()
+    {
+        var items = await _service.GetAllAsync();
+        return Ok(items);
+    }
+}

--- a/Server.Api/Server.Api/Controllers/PermissionsController.cs
+++ b/Server.Api/Server.Api/Controllers/PermissionsController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+using GovServices.Server.DTOs;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class PermissionsController : ControllerBase
+{
+    private readonly IPermissionService _service;
+    public PermissionsController(IPermissionService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<PermissionDto>>> Get()
+    {
+        var items = await _service.GetAllAsync();
+        return Ok(items);
+    }
+}

--- a/Server.Api/Server.Api/Controllers/PositionsController.cs
+++ b/Server.Api/Server.Api/Controllers/PositionsController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+using GovServices.Server.DTOs;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class PositionsController : ControllerBase
+{
+    private readonly IPositionService _service;
+    public PositionsController(IPositionService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<PositionDto>>> Get()
+    {
+        var items = await _service.GetAllAsync();
+        return Ok(items);
+    }
+}

--- a/Server.Api/Server.Api/Controllers/UserProfilesController.cs
+++ b/Server.Api/Server.Api/Controllers/UserProfilesController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+using GovServices.Server.DTOs;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class UserProfilesController : ControllerBase
+{
+    private readonly IUserProfileService _service;
+    public UserProfilesController(IUserProfileService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<UserProfileDto>>> Get()
+    {
+        var items = await _service.GetAllAsync();
+        return Ok(items);
+    }
+}

--- a/Server.Api/Server.Api/DTOs/CreatePermissionDto.cs
+++ b/Server.Api/Server.Api/DTOs/CreatePermissionDto.cs
@@ -1,0 +1,12 @@
+namespace GovServices.Server.DTOs;
+
+public class CreatePermissionDto
+{
+    public string Role { get; set; } = string.Empty;
+    public bool CanView { get; set; }
+    public bool CanEdit { get; set; }
+    public bool CanApprove { get; set; }
+    public bool CanDelete { get; set; }
+    public int ServiceId { get; set; }
+    public int DepartmentId { get; set; }
+}

--- a/Server.Api/Server.Api/DTOs/CreatePositionDto.cs
+++ b/Server.Api/Server.Api/DTOs/CreatePositionDto.cs
@@ -1,0 +1,8 @@
+namespace GovServices.Server.DTOs;
+
+public class CreatePositionDto
+{
+    public string Name { get; set; } = string.Empty;
+    public int DepartmentId { get; set; }
+    public int StaffLimit { get; set; }
+}

--- a/Server.Api/Server.Api/DTOs/CreateUserProfileDto.cs
+++ b/Server.Api/Server.Api/DTOs/CreateUserProfileDto.cs
@@ -1,0 +1,11 @@
+namespace GovServices.Server.DTOs;
+
+public class CreateUserProfileDto
+{
+    public string UserId { get; set; } = string.Empty;
+    public string FullName { get; set; } = string.Empty;
+    public int PositionId { get; set; }
+    public int DepartmentId { get; set; }
+    public bool IsActive { get; set; } = true;
+    public int? SupervisorId { get; set; }
+}

--- a/Server.Api/Server.Api/DTOs/DepartmentDto.cs
+++ b/Server.Api/Server.Api/DTOs/DepartmentDto.cs
@@ -1,0 +1,9 @@
+namespace GovServices.Server.DTOs;
+
+public class DepartmentDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int? ParentDepartmentId { get; set; }
+    public string? Description { get; set; }
+}

--- a/Server.Api/Server.Api/DTOs/PermissionDto.cs
+++ b/Server.Api/Server.Api/DTOs/PermissionDto.cs
@@ -1,0 +1,13 @@
+namespace GovServices.Server.DTOs;
+
+public class PermissionDto
+{
+    public int Id { get; set; }
+    public string Role { get; set; } = string.Empty;
+    public bool CanView { get; set; }
+    public bool CanEdit { get; set; }
+    public bool CanApprove { get; set; }
+    public bool CanDelete { get; set; }
+    public int ServiceId { get; set; }
+    public int DepartmentId { get; set; }
+}

--- a/Server.Api/Server.Api/DTOs/PositionDto.cs
+++ b/Server.Api/Server.Api/DTOs/PositionDto.cs
@@ -1,0 +1,9 @@
+namespace GovServices.Server.DTOs;
+
+public class PositionDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int DepartmentId { get; set; }
+    public int StaffLimit { get; set; }
+}

--- a/Server.Api/Server.Api/DTOs/UpdatePermissionDto.cs
+++ b/Server.Api/Server.Api/DTOs/UpdatePermissionDto.cs
@@ -1,0 +1,11 @@
+namespace GovServices.Server.DTOs;
+
+public class UpdatePermissionDto
+{
+    public bool CanView { get; set; }
+    public bool CanEdit { get; set; }
+    public bool CanApprove { get; set; }
+    public bool CanDelete { get; set; }
+    public int ServiceId { get; set; }
+    public int DepartmentId { get; set; }
+}

--- a/Server.Api/Server.Api/DTOs/UpdatePositionDto.cs
+++ b/Server.Api/Server.Api/DTOs/UpdatePositionDto.cs
@@ -1,0 +1,8 @@
+namespace GovServices.Server.DTOs;
+
+public class UpdatePositionDto
+{
+    public string Name { get; set; } = string.Empty;
+    public int DepartmentId { get; set; }
+    public int StaffLimit { get; set; }
+}

--- a/Server.Api/Server.Api/DTOs/UpdateUserProfileDto.cs
+++ b/Server.Api/Server.Api/DTOs/UpdateUserProfileDto.cs
@@ -1,0 +1,10 @@
+namespace GovServices.Server.DTOs;
+
+public class UpdateUserProfileDto
+{
+    public string FullName { get; set; } = string.Empty;
+    public int PositionId { get; set; }
+    public int DepartmentId { get; set; }
+    public bool IsActive { get; set; }
+    public int? SupervisorId { get; set; }
+}

--- a/Server.Api/Server.Api/DTOs/UserProfileDto.cs
+++ b/Server.Api/Server.Api/DTOs/UserProfileDto.cs
@@ -1,0 +1,12 @@
+namespace GovServices.Server.DTOs;
+
+public class UserProfileDto
+{
+    public int Id { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public string FullName { get; set; } = string.Empty;
+    public int PositionId { get; set; }
+    public int DepartmentId { get; set; }
+    public bool IsActive { get; set; }
+    public int? SupervisorId { get; set; }
+}

--- a/Server.Api/Server.Api/Data/ApplicationDbContext.cs
+++ b/Server.Api/Server.Api/Data/ApplicationDbContext.cs
@@ -38,6 +38,8 @@ namespace GovServices.Server.Data
         public DbSet<PermissionGroup> PermissionGroups { get; set; }
         public DbSet<PermissionGroupPermission> PermissionGroupPermissions { get; set; }
         public DbSet<UserPermissionGroup> UserPermissionGroups { get; set; }
+        public DbSet<Position> Positions { get; set; }
+        public DbSet<UserProfile> UserProfiles { get; set; }
         public DbSet<Dictionary> Dictionaries { get; set; }
         public DbSet<NumberTemplate> NumberTemplates { get; set; }
         public DbSet<NumberTemplateCounter> NumberTemplateCounters { get; set; }
@@ -82,6 +84,53 @@ namespace GovServices.Server.Data
             builder.Entity<NumberTemplateCounter>()
                 .HasIndex(c => new { c.TemplateId, c.ScopeKey })
                 .IsUnique();
+
+            builder.Entity<Department>()
+                .HasOne(d => d.ParentDepartment)
+                .WithMany(d => d.ChildDepartments)
+                .HasForeignKey(d => d.ParentDepartmentId);
+
+            builder.Entity<Position>()
+                .HasOne(p => p.Department)
+                .WithMany(d => d.Positions)
+                .HasForeignKey(p => p.DepartmentId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.Entity<UserProfile>()
+                .HasOne(u => u.User)
+                .WithOne()
+                .HasForeignKey<UserProfile>(u => u.UserId);
+
+            builder.Entity<UserProfile>()
+                .HasOne(u => u.Position)
+                .WithMany(p => p.UserProfiles)
+                .HasForeignKey(u => u.PositionId);
+
+            builder.Entity<UserProfile>()
+                .HasOne(u => u.Department)
+                .WithMany()
+                .HasForeignKey(u => u.DepartmentId);
+
+            builder.Entity<UserProfile>()
+                .HasOne(u => u.Supervisor)
+                .WithMany(s => s.Subordinates)
+                .HasForeignKey(u => u.SupervisorId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            builder.Entity<Service>()
+                .HasOne(s => s.ResponsibleDepartment)
+                .WithMany()
+                .HasForeignKey(s => s.ResponsibleDepartmentId);
+
+            builder.Entity<Permission>()
+                .HasOne(p => p.Service)
+                .WithMany()
+                .HasForeignKey(p => p.ServiceId);
+
+            builder.Entity<Permission>()
+                .HasOne(p => p.Department)
+                .WithMany()
+                .HasForeignKey(p => p.DepartmentId);
         }
     }
 }

--- a/Server.Api/Server.Api/Entities/Department.cs
+++ b/Server.Api/Server.Api/Entities/Department.cs
@@ -1,9 +1,13 @@
-namespace GovServices.Server.Entities
+namespace GovServices.Server.Entities;
+
+public class Department
 {
-    public class Department
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-        public ICollection<ApplicationUser> Users { get; set; }
-    }
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int? ParentDepartmentId { get; set; }
+    public Department? ParentDepartment { get; set; }
+    public ICollection<Department> ChildDepartments { get; set; } = new List<Department>();
+    public string? Description { get; set; }
+    public ICollection<ApplicationUser> Users { get; set; } = new List<ApplicationUser>();
+    public ICollection<Position> Positions { get; set; } = new List<Position>();
 }

--- a/Server.Api/Server.Api/Entities/Permission.cs
+++ b/Server.Api/Server.Api/Entities/Permission.cs
@@ -3,6 +3,15 @@ namespace GovServices.Server.Entities;
 public class Permission
 {
     public int Id { get; set; }
-    public string Name { get; set; }
-    public ICollection<PermissionGroupPermission> PermissionGroupPermissions { get; set; }
+    public string? Name { get; set; }
+    public string Role { get; set; } = string.Empty;
+    public bool CanView { get; set; }
+    public bool CanEdit { get; set; }
+    public bool CanApprove { get; set; }
+    public bool CanDelete { get; set; }
+    public int ServiceId { get; set; }
+    public Service Service { get; set; } = default!;
+    public int DepartmentId { get; set; }
+    public Department Department { get; set; } = default!;
+    public ICollection<PermissionGroupPermission> PermissionGroupPermissions { get; set; } = new List<PermissionGroupPermission>();
 }

--- a/Server.Api/Server.Api/Entities/Position.cs
+++ b/Server.Api/Server.Api/Entities/Position.cs
@@ -1,0 +1,11 @@
+namespace GovServices.Server.Entities;
+
+public class Position
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int DepartmentId { get; set; }
+    public Department Department { get; set; } = default!;
+    public int StaffLimit { get; set; }
+    public ICollection<UserProfile> UserProfiles { get; set; } = new List<UserProfile>();
+}

--- a/Server.Api/Server.Api/Entities/Service.cs
+++ b/Server.Api/Server.Api/Entities/Service.cs
@@ -5,6 +5,8 @@ namespace GovServices.Server.Entities
         public int Id { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
+        public int? ResponsibleDepartmentId { get; set; }
+        public Department? ResponsibleDepartment { get; set; }
         public int? ExecutionDeadlineDays { get; set; }
         public DateTime? ExecutionDeadlineDate { get; set; }
         public string? ExecutionStagesJson { get; set; }

--- a/Server.Api/Server.Api/Entities/UserProfile.cs
+++ b/Server.Api/Server.Api/Entities/UserProfile.cs
@@ -1,0 +1,17 @@
+namespace GovServices.Server.Entities;
+
+public class UserProfile
+{
+    public int Id { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public ApplicationUser User { get; set; } = default!;
+    public string FullName { get; set; } = string.Empty;
+    public int PositionId { get; set; }
+    public Position Position { get; set; } = default!;
+    public int DepartmentId { get; set; }
+    public Department Department { get; set; } = default!;
+    public bool IsActive { get; set; } = true;
+    public int? SupervisorId { get; set; }
+    public UserProfile? Supervisor { get; set; }
+    public ICollection<UserProfile> Subordinates { get; set; } = new List<UserProfile>();
+}

--- a/Server.Api/Server.Api/Interfaces/IDepartmentService.cs
+++ b/Server.Api/Server.Api/Interfaces/IDepartmentService.cs
@@ -1,0 +1,8 @@
+using GovServices.Server.DTOs;
+
+namespace GovServices.Server.Interfaces;
+
+public interface IDepartmentService
+{
+    Task<List<DepartmentDto>> GetAllAsync();
+}

--- a/Server.Api/Server.Api/Interfaces/IPermissionService.cs
+++ b/Server.Api/Server.Api/Interfaces/IPermissionService.cs
@@ -1,0 +1,8 @@
+using GovServices.Server.DTOs;
+
+namespace GovServices.Server.Interfaces;
+
+public interface IPermissionService
+{
+    Task<List<PermissionDto>> GetAllAsync();
+}

--- a/Server.Api/Server.Api/Interfaces/IPositionService.cs
+++ b/Server.Api/Server.Api/Interfaces/IPositionService.cs
@@ -1,0 +1,8 @@
+using GovServices.Server.DTOs;
+
+namespace GovServices.Server.Interfaces;
+
+public interface IPositionService
+{
+    Task<List<PositionDto>> GetAllAsync();
+}

--- a/Server.Api/Server.Api/Interfaces/IUserProfileService.cs
+++ b/Server.Api/Server.Api/Interfaces/IUserProfileService.cs
@@ -1,0 +1,8 @@
+using GovServices.Server.DTOs;
+
+namespace GovServices.Server.Interfaces;
+
+public interface IUserProfileService
+{
+    Task<List<UserProfileDto>> GetAllAsync();
+}

--- a/Server.Api/Server.Api/Mappings/MappingProfile.cs
+++ b/Server.Api/Server.Api/Mappings/MappingProfile.cs
@@ -4,6 +4,7 @@ using GovServices.Server.DTOs;
 using System;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
+using PositionEntity = GovServices.Server.Entities.Position;
 using System.Linq;
 using System.Collections.Generic;
 using System.Text.Json;
@@ -114,6 +115,17 @@ namespace GovServices.Server.Mappings
             CreateMap<UpdateServiceTemplateDto, ServiceTemplate>();
 
             CreateMap<Dictionary, DictionaryDto>();
+
+            CreateMap<Department, DepartmentDto>().ReverseMap();
+            CreateMap<PositionEntity, PositionDto>().ReverseMap();
+            CreateMap<CreatePositionDto, PositionEntity>();
+            CreateMap<UpdatePositionDto, PositionEntity>();
+            CreateMap<UserProfile, UserProfileDto>().ReverseMap();
+            CreateMap<CreateUserProfileDto, UserProfile>();
+            CreateMap<UpdateUserProfileDto, UserProfile>();
+            CreateMap<Permission, PermissionDto>().ReverseMap();
+            CreateMap<CreatePermissionDto, Permission>();
+            CreateMap<UpdatePermissionDto, Permission>();
         }
 
         private static List<ExecutionStage>? DeserializeStages(string? json)

--- a/Server.Api/Server.Api/Migrations/20250623140845_AddUserHierarchy.Designer.cs
+++ b/Server.Api/Server.Api/Migrations/20250623140845_AddUserHierarchy.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using GovServices.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Server.Api.Migrations
+namespace Server.Api.Server.Api.Server.Api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250623140845_AddUserHierarchy")]
+    partial class AddUserHierarchy
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server.Api/Server.Api/Migrations/20250623140845_AddUserHierarchy.cs
+++ b/Server.Api/Server.Api/Migrations/20250623140845_AddUserHierarchy.cs
@@ -1,0 +1,321 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Server.Api.Server.Api.Server.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserHierarchy : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ResponsibleDepartmentId",
+                table: "Services",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Permissions",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "CanApprove",
+                table: "Permissions",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "CanDelete",
+                table: "Permissions",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "CanEdit",
+                table: "Permissions",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "CanView",
+                table: "Permissions",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "DepartmentId",
+                table: "Permissions",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Role",
+                table: "Permissions",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "ServiceId",
+                table: "Permissions",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "Departments",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ParentDepartmentId",
+                table: "Departments",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Positions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "text", nullable: false),
+                    DepartmentId = table.Column<int>(type: "integer", nullable: false),
+                    StaffLimit = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Positions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Positions_Departments_DepartmentId",
+                        column: x => x.DepartmentId,
+                        principalTable: "Departments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UserProfiles",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<string>(type: "text", nullable: false),
+                    FullName = table.Column<string>(type: "text", nullable: false),
+                    PositionId = table.Column<int>(type: "integer", nullable: false),
+                    DepartmentId = table.Column<int>(type: "integer", nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    SupervisorId = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserProfiles", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserProfiles_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserProfiles_Departments_DepartmentId",
+                        column: x => x.DepartmentId,
+                        principalTable: "Departments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserProfiles_Positions_PositionId",
+                        column: x => x.PositionId,
+                        principalTable: "Positions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserProfiles_UserProfiles_SupervisorId",
+                        column: x => x.SupervisorId,
+                        principalTable: "UserProfiles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Services_ResponsibleDepartmentId",
+                table: "Services",
+                column: "ResponsibleDepartmentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Permissions_DepartmentId",
+                table: "Permissions",
+                column: "DepartmentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Permissions_ServiceId",
+                table: "Permissions",
+                column: "ServiceId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Departments_ParentDepartmentId",
+                table: "Departments",
+                column: "ParentDepartmentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Positions_DepartmentId",
+                table: "Positions",
+                column: "DepartmentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserProfiles_DepartmentId",
+                table: "UserProfiles",
+                column: "DepartmentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserProfiles_PositionId",
+                table: "UserProfiles",
+                column: "PositionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserProfiles_SupervisorId",
+                table: "UserProfiles",
+                column: "SupervisorId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserProfiles_UserId",
+                table: "UserProfiles",
+                column: "UserId",
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Departments_Departments_ParentDepartmentId",
+                table: "Departments",
+                column: "ParentDepartmentId",
+                principalTable: "Departments",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Permissions_Departments_DepartmentId",
+                table: "Permissions",
+                column: "DepartmentId",
+                principalTable: "Departments",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Permissions_Services_ServiceId",
+                table: "Permissions",
+                column: "ServiceId",
+                principalTable: "Services",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Services_Departments_ResponsibleDepartmentId",
+                table: "Services",
+                column: "ResponsibleDepartmentId",
+                principalTable: "Departments",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Departments_Departments_ParentDepartmentId",
+                table: "Departments");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Permissions_Departments_DepartmentId",
+                table: "Permissions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Permissions_Services_ServiceId",
+                table: "Permissions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Services_Departments_ResponsibleDepartmentId",
+                table: "Services");
+
+            migrationBuilder.DropTable(
+                name: "UserProfiles");
+
+            migrationBuilder.DropTable(
+                name: "Positions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Services_ResponsibleDepartmentId",
+                table: "Services");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Permissions_DepartmentId",
+                table: "Permissions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Permissions_ServiceId",
+                table: "Permissions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Departments_ParentDepartmentId",
+                table: "Departments");
+
+            migrationBuilder.DropColumn(
+                name: "ResponsibleDepartmentId",
+                table: "Services");
+
+            migrationBuilder.DropColumn(
+                name: "CanApprove",
+                table: "Permissions");
+
+            migrationBuilder.DropColumn(
+                name: "CanDelete",
+                table: "Permissions");
+
+            migrationBuilder.DropColumn(
+                name: "CanEdit",
+                table: "Permissions");
+
+            migrationBuilder.DropColumn(
+                name: "CanView",
+                table: "Permissions");
+
+            migrationBuilder.DropColumn(
+                name: "DepartmentId",
+                table: "Permissions");
+
+            migrationBuilder.DropColumn(
+                name: "Role",
+                table: "Permissions");
+
+            migrationBuilder.DropColumn(
+                name: "ServiceId",
+                table: "Permissions");
+
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "Departments");
+
+            migrationBuilder.DropColumn(
+                name: "ParentDepartmentId",
+                table: "Departments");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Permissions",
+                type: "text",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+        }
+    }
+}

--- a/Server.Api/Server.Api/Program.cs
+++ b/Server.Api/Server.Api/Program.cs
@@ -130,6 +130,10 @@ builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<IDocumentStorageService, DocumentStorageService>();
 builder.Services.AddScoped<IDictionaryService, DictionaryService>();
 builder.Services.AddSingleton<IDictionaryCacheService, DictionaryCacheService>();
+builder.Services.AddScoped<IDepartmentService, DepartmentService>();
+builder.Services.AddScoped<IPositionService, PositionService>();
+builder.Services.AddScoped<IUserProfileService, UserProfileService>();
+builder.Services.AddScoped<IPermissionService, PermissionService>();
 
 // Регистрация IEmailService (и реализация EmailService)
 builder.Services.AddScoped<IEmailService, EmailService>();

--- a/Server.Api/Server.Api/Services/DepartmentService.cs
+++ b/Server.Api/Server.Api/Services/DepartmentService.cs
@@ -1,0 +1,25 @@
+using GovServices.Server.Data;
+using GovServices.Server.DTOs;
+using GovServices.Server.Interfaces;
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovServices.Server.Services;
+
+public class DepartmentService : IDepartmentService
+{
+    private readonly ApplicationDbContext _context;
+    private readonly IMapper _mapper;
+
+    public DepartmentService(ApplicationDbContext context, IMapper mapper)
+    {
+        _context = context;
+        _mapper = mapper;
+    }
+
+    public async Task<List<DepartmentDto>> GetAllAsync()
+    {
+        var entities = await _context.Departments.ToListAsync();
+        return _mapper.Map<List<DepartmentDto>>(entities);
+    }
+}

--- a/Server.Api/Server.Api/Services/PermissionService.cs
+++ b/Server.Api/Server.Api/Services/PermissionService.cs
@@ -1,0 +1,25 @@
+using GovServices.Server.Data;
+using GovServices.Server.DTOs;
+using GovServices.Server.Interfaces;
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovServices.Server.Services;
+
+public class PermissionService : IPermissionService
+{
+    private readonly ApplicationDbContext _context;
+    private readonly IMapper _mapper;
+
+    public PermissionService(ApplicationDbContext context, IMapper mapper)
+    {
+        _context = context;
+        _mapper = mapper;
+    }
+
+    public async Task<List<PermissionDto>> GetAllAsync()
+    {
+        var entities = await _context.Permissions.ToListAsync();
+        return _mapper.Map<List<PermissionDto>>(entities);
+    }
+}

--- a/Server.Api/Server.Api/Services/PositionService.cs
+++ b/Server.Api/Server.Api/Services/PositionService.cs
@@ -1,0 +1,25 @@
+using GovServices.Server.Data;
+using GovServices.Server.DTOs;
+using GovServices.Server.Interfaces;
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovServices.Server.Services;
+
+public class PositionService : IPositionService
+{
+    private readonly ApplicationDbContext _context;
+    private readonly IMapper _mapper;
+
+    public PositionService(ApplicationDbContext context, IMapper mapper)
+    {
+        _context = context;
+        _mapper = mapper;
+    }
+
+    public async Task<List<PositionDto>> GetAllAsync()
+    {
+        var entities = await _context.Positions.ToListAsync();
+        return _mapper.Map<List<PositionDto>>(entities);
+    }
+}

--- a/Server.Api/Server.Api/Services/UserProfileService.cs
+++ b/Server.Api/Server.Api/Services/UserProfileService.cs
@@ -1,0 +1,25 @@
+using GovServices.Server.Data;
+using GovServices.Server.DTOs;
+using GovServices.Server.Interfaces;
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovServices.Server.Services;
+
+public class UserProfileService : IUserProfileService
+{
+    private readonly ApplicationDbContext _context;
+    private readonly IMapper _mapper;
+
+    public UserProfileService(ApplicationDbContext context, IMapper mapper)
+    {
+        _context = context;
+        _mapper = mapper;
+    }
+
+    public async Task<List<UserProfileDto>> GetAllAsync()
+    {
+        var entities = await _context.UserProfiles.ToListAsync();
+        return _mapper.Map<List<UserProfileDto>>(entities);
+    }
+}


### PR DESCRIPTION
## Summary
- extend Department entity with hierarchy
- add Position and UserProfile entities
- add Department, Position, UserProfile, Permission DTOs and services
- add Blazor pages for departments, positions and permissions using Syncfusion components
- register new menu groups in MenuService
- update EF DbContext and add migration
- add API controllers and clients

## Testing
- `dotnet build Server.Api/Server.Api/Server.Api.csproj`
- `dotnet build Client.Wasm/Client.Wasm/Client.Wasm.csproj`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68595e27340c8323971881786d206555