### PR TITLE
Seed base data

### DIFF
--- a/Server.Api/Server.Api/Authorization/RoleNames.cs
+++ b/Server.Api/Server.Api/Authorization/RoleNames.cs
@@ -6,6 +6,7 @@ public static class RoleNames
     public const string Registrar = "Регистратор";
     public const string Analyst = "Аналитик";
     public const string Lawyer = "Юрист";
+    public const string Specialist = "Специалист";
     public const string DepartmentHead = "Начальник отдела";
     public const string ManagementHead = "Начальник управления";
     public const string Director = "Директор";

--- a/Server.Api/Server.Api/Data/ApplicationDbContext.cs
+++ b/Server.Api/Server.Api/Data/ApplicationDbContext.cs
@@ -1,5 +1,6 @@
 using GovServices.Server.Entities;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
 namespace GovServices.Server.Data
@@ -131,6 +132,67 @@ namespace GovServices.Server.Data
                 .HasOne(p => p.Department)
                 .WithMany()
                 .HasForeignKey(p => p.DepartmentId);
+
+            var createdAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            builder.Entity<Department>().HasData(
+                new Department { Id = SeedData.Departments.IT, Name = "IT" },
+                new Department { Id = SeedData.Departments.Legal, Name = "Юридический" },
+                new Department { Id = SeedData.Departments.HR, Name = "Кадры" }
+            );
+
+            builder.Entity<Service>().HasData(
+                new Service
+                {
+                    Id = SeedData.DefaultServiceId,
+                    Name = "Базовая услуга",
+                    Description = "Сервис по умолчанию",
+                    CreatedAt = createdAt,
+                    UpdatedAt = createdAt
+                }
+            );
+
+            builder.Entity<IdentityRole>().HasData(
+                new IdentityRole
+                {
+                    Id = "8fd9f63e-0001-4000-8000-000000000001",
+                    Name = SeedData.Roles.Specialist,
+                    NormalizedName = SeedData.Roles.Specialist.ToUpper()
+                },
+                new IdentityRole
+                {
+                    Id = "8fd9f63e-0002-4000-8000-000000000002",
+                    Name = SeedData.Roles.DepartmentHead,
+                    NormalizedName = SeedData.Roles.DepartmentHead.ToUpper()
+                },
+                new IdentityRole
+                {
+                    Id = "8fd9f63e-0003-4000-8000-000000000003",
+                    Name = SeedData.Roles.ManagementHead,
+                    NormalizedName = SeedData.Roles.ManagementHead.ToUpper()
+                }
+            );
+
+            builder.Entity<Permission>().HasData(
+                new Permission
+                {
+                    Id = SeedData.Permissions.AccessApplications,
+                    Name = "Доступ к заявлениям",
+                    DepartmentId = SeedData.Departments.IT,
+                    Role = SeedData.Roles.Specialist,
+                    ServiceId = SeedData.DefaultServiceId,
+                    CanView = true
+                },
+                new Permission
+                {
+                    Id = SeedData.Permissions.EditContracts,
+                    Name = "Редактирование договоров",
+                    DepartmentId = SeedData.Departments.Legal,
+                    Role = SeedData.Roles.DepartmentHead,
+                    ServiceId = SeedData.DefaultServiceId,
+                    CanEdit = true
+                }
+            );
         }
     }
 }

--- a/Server.Api/Server.Api/Data/DataSeeder.cs
+++ b/Server.Api/Server.Api/Data/DataSeeder.cs
@@ -18,6 +18,7 @@ namespace GovServices.Server.Data
                 RoleNames.Registrar,
                 RoleNames.Analyst,
                 RoleNames.Lawyer,
+                RoleNames.Specialist,
                 RoleNames.DepartmentHead,
                 RoleNames.ManagementHead,
                 RoleNames.Director,

--- a/Server.Api/Server.Api/Data/DatabaseInitializer.cs
+++ b/Server.Api/Server.Api/Data/DatabaseInitializer.cs
@@ -1,0 +1,74 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using GovServices.Server.Entities;
+
+namespace GovServices.Server.Data;
+
+public static class DatabaseInitializer
+{
+    public static async Task SeedAsync(IServiceProvider services)
+    {
+        using var scope = services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+
+        await context.Database.MigrateAsync();
+
+        if (!context.Departments.Any())
+        {
+            context.Departments.AddRange(
+                new Department { Id = SeedData.Departments.IT, Name = "IT" },
+                new Department { Id = SeedData.Departments.Legal, Name = "Юридический" },
+                new Department { Id = SeedData.Departments.HR, Name = "Кадры" }
+            );
+            await context.SaveChangesAsync();
+        }
+
+        foreach (var roleName in new[] { SeedData.Roles.Specialist, SeedData.Roles.DepartmentHead, SeedData.Roles.ManagementHead })
+        {
+            if (!await roleManager.RoleExistsAsync(roleName))
+            {
+                await roleManager.CreateAsync(new IdentityRole(roleName));
+            }
+        }
+
+        if (!context.Permissions.Any())
+        {
+            var createdAt = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            if (!context.Services.Any(s => s.Id == SeedData.DefaultServiceId))
+            {
+                context.Services.Add(new Service
+                {
+                    Id = SeedData.DefaultServiceId,
+                    Name = "Базовая услуга",
+                    Description = "Сервис по умолчанию",
+                    CreatedAt = createdAt,
+                    UpdatedAt = createdAt
+                });
+                await context.SaveChangesAsync();
+            }
+
+            context.Permissions.AddRange(
+                new Permission
+                {
+                    Id = SeedData.Permissions.AccessApplications,
+                    Name = "Доступ к заявлениям",
+                    DepartmentId = SeedData.Departments.IT,
+                    Role = SeedData.Roles.Specialist,
+                    ServiceId = SeedData.DefaultServiceId,
+                    CanView = true
+                },
+                new Permission
+                {
+                    Id = SeedData.Permissions.EditContracts,
+                    Name = "Редактирование договоров",
+                    DepartmentId = SeedData.Departments.Legal,
+                    Role = SeedData.Roles.DepartmentHead,
+                    ServiceId = SeedData.DefaultServiceId,
+                    CanEdit = true
+                }
+            );
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/Server.Api/Server.Api/Data/SeedData.cs
+++ b/Server.Api/Server.Api/Data/SeedData.cs
@@ -1,0 +1,26 @@
+namespace GovServices.Server.Data;
+
+public static class SeedData
+{
+    public static class Departments
+    {
+        public const int IT = 1;
+        public const int Legal = 2;
+        public const int HR = 3;
+    }
+
+    public static class Roles
+    {
+        public const string Specialist = "Специалист";
+        public const string DepartmentHead = "Начальник отдела";
+        public const string ManagementHead = "Начальник управления";
+    }
+
+    public static class Permissions
+    {
+        public const int AccessApplications = 1;
+        public const int EditContracts = 2;
+    }
+
+    public const int DefaultServiceId = 1;
+}

--- a/Server.Api/Server.Api/Migrations/20250623144453_SeedBaseData.Designer.cs
+++ b/Server.Api/Server.Api/Migrations/20250623144453_SeedBaseData.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using GovServices.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Server.Api.Migrations
+namespace Server.Api.Server.Api.Server.Api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250623144453_SeedBaseData")]
+    partial class SeedBaseData
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server.Api/Server.Api/Migrations/20250623144453_SeedBaseData.cs
+++ b/Server.Api/Server.Api/Migrations/20250623144453_SeedBaseData.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace Server.Api.Server.Api.Server.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedBaseData : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "AspNetRoles",
+                columns: new[] { "Id", "ConcurrencyStamp", "Name", "NormalizedName" },
+                values: new object[,]
+                {
+                    { "8fd9f63e-0001-4000-8000-000000000001", null, "Специалист", "СПЕЦИАЛИСТ" },
+                    { "8fd9f63e-0002-4000-8000-000000000002", null, "Начальник отдела", "НАЧАЛЬНИК ОТДЕЛА" },
+                    { "8fd9f63e-0003-4000-8000-000000000003", null, "Начальник управления", "НАЧАЛЬНИК УПРАВЛЕНИЯ" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "Departments",
+                columns: new[] { "Id", "Description", "Name", "ParentDepartmentId" },
+                values: new object[,]
+                {
+                    { 1, null, "IT", null },
+                    { 2, null, "Юридический", null },
+                    { 3, null, "Кадры", null }
+                });
+
+            migrationBuilder.InsertData(
+                table: "Services",
+                columns: new[] { "Id", "CreatedAt", "Description", "ExecutionDeadlineDate", "ExecutionDeadlineDays", "ExecutionStagesJson", "Name", "ResponsibleDepartmentId", "Status", "UpdatedAt" },
+                values: new object[] { 1, new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), "Сервис по умолчанию", null, null, null, "Базовая услуга", null, "В процессе", new DateTime(2024, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc) });
+
+            migrationBuilder.InsertData(
+                table: "Permissions",
+                columns: new[] { "Id", "CanApprove", "CanDelete", "CanEdit", "CanView", "DepartmentId", "Name", "Role", "ServiceId" },
+                values: new object[,]
+                {
+                    { 1, false, false, false, true, 1, "Доступ к заявлениям", "Специалист", 1 },
+                    { 2, false, false, true, false, 2, "Редактирование договоров", "Начальник отдела", 1 }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "8fd9f63e-0001-4000-8000-000000000001");
+
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "8fd9f63e-0002-4000-8000-000000000002");
+
+            migrationBuilder.DeleteData(
+                table: "AspNetRoles",
+                keyColumn: "Id",
+                keyValue: "8fd9f63e-0003-4000-8000-000000000003");
+
+            migrationBuilder.DeleteData(
+                table: "Departments",
+                keyColumn: "Id",
+                keyValue: 3);
+
+            migrationBuilder.DeleteData(
+                table: "Permissions",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "Permissions",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "Departments",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "Departments",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "Services",
+                keyColumn: "Id",
+                keyValue: 1);
+        }
+    }
+}

--- a/Server.Api/Server.Api/Program.cs
+++ b/Server.Api/Server.Api/Program.cs
@@ -161,6 +161,7 @@ var app = builder.Build();
 
 using (var scope = app.Services.CreateScope())
 {
+    await DatabaseInitializer.SeedAsync(scope.ServiceProvider);
     await DataSeeder.SeedAsync(scope.ServiceProvider);
     var cache = scope.ServiceProvider.GetRequiredService<IDictionaryCacheService>();
     await cache.ReloadAsync();


### PR DESCRIPTION
## Summary
- seed constants for departments, roles and permissions
- seed base data via `OnModelCreating`
- ensure runtime seeding through `DatabaseInitializer`
- call the new initializer from `Program`
- generate EF Core migration

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_685966b9e0708323a1a97cdd5fd3369c