### PR TITLE
Fix bootstrap integrity and menu event

### DIFF
--- a/Client.Wasm/Client.Wasm/Client.Wasm.csproj
+++ b/Client.Wasm/Client.Wasm/Client.Wasm.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Syncfusion.Blazor.Inputs" Version="29.2.11" />
     <PackageReference Include="Syncfusion.Blazor.Grid" Version="29.2.11" />
     <PackageReference Include="Syncfusion.Blazor.DropDowns" Version="29.2.11" />
-    <PackageReference Include="Syncfusion.Blazor.Navigations" Version="29.2.11" />
+    <PackageReference Include="Syncfusion.Blazor.Navigations" Version="29.2.11.0" />
     <PackageReference Include="Syncfusion.Blazor.Notifications" Version="29.2.11" />
     <PackageReference Include="Syncfusion.Blazor.PdfViewer" Version="27.1.58" />
     <PackageReference Include="Syncfusion.Blazor.Popups" Version="29.2.11" />

--- a/Client.Wasm/Client.Wasm/Components/TopNav.razor
+++ b/Client.Wasm/Client.Wasm/Components/TopNav.razor
@@ -17,7 +17,7 @@
                              CssClass="bootstrap5 top-nav-menu"
                              Orientation="Syncfusion.Blazor.Navigations.Orientation.Horizontal"
                              ShowItemOnClick="true">
-                        <MenuEvents TValue="MenuItem" ItemClicked="OnItemClicked" />
+                        <MenuEvents TValue="MenuItem" OnItemSelected="HandleMenuItemSelected" />
                     </SfMenu>
                     <!-- Меню пользователя в правом верхнем углу -->
                     <SfDropDownButton CssClass="e-flat profile-button" IconCss="e-icons e-user" Items="UserItems" ItemSelected="OnUserItemSelected"></SfDropDownButton>
@@ -106,7 +106,7 @@
 
     protected override Task OnInitializedAsync() => Task.CompletedTask;
 
-    private void OnItemClicked(MenuEventArgs<MenuItem> args)
+    private void HandleMenuItemSelected(MenuEventArgs<MenuItem> args)
     {
         Console.WriteLine(args.Item.Text);
         if (!string.IsNullOrEmpty(args.Item.Url))

--- a/Client.Wasm/Client.Wasm/wwwroot/index.html
+++ b/Client.Wasm/Client.Wasm/wwwroot/index.html
@@ -39,7 +39,7 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-C7ZD/IYAl4XrhIRbkIuAeGHNirMRHkRkNvztNFVQVw1Gc7jqhcUMIqFZ3VAbwY/j" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-62fa5cad87f4b58de51c1eb434d9265dce6cf5f0d564b112680039e4d0f33b1872f4691c21db252b578decdea321e1f3" crossorigin="anonymous"></script>
     <script src="https://cdn.syncfusion.com/blazor/29.2.11/syncfusion-blazor.min.js"></script>
     <script src="_content/Syncfusion.Blazor.Core/scripts/syncfusion-blazor.min.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>


### PR DESCRIPTION
## Summary
- update bootstrap bundle integrity hash
- use `OnItemSelected` event for menu
- rename item click handler
- set Syncfusion Navigations package to version 29.2.11.0

## Testing
- `dotnet build GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_685968ec25f08323a2925b1285542857