### PR TITLE
Fix permission seeding and connection string

### DIFF
--- a/Server.Api/Server.Api/AppSettings.example.json
+++ b/Server.Api/Server.Api/AppSettings.example.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=db;Port=5432;Database=gov_services;Username=postgres;Password=postgres"
+    "DefaultConnection": "Host=db;Port=5432;Database=gov_services;Username=postgres;Password=postgres;Include Error Detail=true"
   },
   "JwtSettings": {
     "Key": "YOUR_SUPER_SECRET_KEY",

--- a/Server.Api/Server.Api/Data/DataSeeder.cs
+++ b/Server.Api/Server.Api/Data/DataSeeder.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Identity;
 using GovServices.Server.Entities;
 using GovServices.Server.Authorization;
+using System;
 
 namespace GovServices.Server.Data
 {
@@ -57,10 +58,38 @@ namespace GovServices.Server.Data
                 PermissionNames.ViewClosedServices
             };
 
+            var defaultDepartmentId = SeedData.Departments.IT;
+            if (!context.Departments.Any(d => d.Id == defaultDepartmentId))
+            {
+                context.Departments.Add(new Department { Id = defaultDepartmentId, Name = "IT" });
+                await context.SaveChangesAsync();
+            }
+
+            if (!context.Services.Any(s => s.Id == SeedData.DefaultServiceId))
+            {
+                context.Services.Add(new Service
+                {
+                    Id = SeedData.DefaultServiceId,
+                    Name = "Базовая услуга",
+                    Description = "Сервис по умолчанию",
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow
+                });
+                await context.SaveChangesAsync();
+            }
+
             foreach (var perm in permissions)
             {
                 if (!context.Permissions.Any(p => p.Name == perm))
-                    context.Permissions.Add(new Permission { Name = perm });
+                {
+                    context.Permissions.Add(new Permission
+                    {
+                        Name = perm,
+                        DepartmentId = defaultDepartmentId,
+                        ServiceId = SeedData.DefaultServiceId,
+                        Role = SeedData.Roles.Specialist
+                    });
+                }
             }
             await context.SaveChangesAsync();
 

--- a/Server.Api/Server.Api/appsettings.json
+++ b/Server.Api/Server.Api/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=govservices;Username=postgres;Password=postgres"
+    "DefaultConnection": "Host=localhost;Port=5432;Database=govservices;Username=postgres;Password=postgres;Include Error Detail=true"
   },
   "Jwt": {
     "Key": "12345678901234567890123456789012",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     depends_on:
       - db
     environment:
-      ConnectionStrings__DefaultConnection: Host=db;Port=5432;Database=gov_services;Username=postgres;Password=postgres
+      ConnectionStrings__DefaultConnection: Host=db;Port=5432;Database=gov_services;Username=postgres;Password=postgres;Include Error Detail=true
       ASPNETCORE_URLS: http://+:80
     ports:
       - "5001:80"


### PR DESCRIPTION
## Summary
- ensure default departments and services exist when seeding permissions
- assign valid DepartmentId and ServiceId while seeding
- enable detailed error messages in postgres connection strings

## Testing
- `dotnet test GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_68596acff2fc83238dd0b22a177295df