### PR TITLE
Migrate initial user pages to MudBlazor

### DIFF
--- a/Client.Wasm/Client.Wasm/Pages/UserEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/UserEdit.razor
@@ -4,41 +4,32 @@
 @inject NavigationManager NavigationManager
 @inject IUserApiClient ApiClient
 
-<SfDialog @ref="dlg" Width="450px" ShowCloseIcon="true" Header="@hdr">
-    <EditForm Model="model" OnValidSubmit="Save">
-        <DataAnnotationsValidator />
-        <SfTab>
-            <TabItems>
-                <TabItem>
-    <ChildContent>
-        <TabHeader Text="Основное"></TabHeader>
-    </ChildContent>
-    <ContentTemplate>
-                    <SfTextBox TValue="string" @bind-Value="model.Email" Placeholder="Email" CssClass="mb-3 w-100" />
-                    <SfTextBox TValue="string" @bind-Value="model.FullName" Placeholder="ФИО" CssClass="mb-3 w-100" />
-                    <SfNumericTextBox TValue="int" @bind-Value="model.DepartmentId" Placeholder="ID отдела" CssClass="mb-3 w-100" />
-                    <SfTextBox TValue="string" @bind-Value="roles" Placeholder="Роли (через запятую)" CssClass="mb-3 w-100" />
-                </ContentTemplate>
-</TabItem>
-                <TabItem>
-    <ChildContent>
-        <TabHeader Text="Дополнительно"></TabHeader>
-    </ChildContent>
-    <ContentTemplate>
+<MudDialog @bind-Visible="open" MaxWidth="MaxWidth.Small">
+    <DialogContent>
+        <MudText Typo="Typo.h6" Class="mb-2">@hdr</MudText>
+        <EditForm Model="model" OnValidSubmit="Save">
+            <DataAnnotationsValidator />
+            <MudTabs>
+                <MudTabPanel Text="Основное">
+                    <MudTextField @bind-Value="model.Email" Label="Email" Class="mb-3 w-100" />
+                    <MudTextField @bind-Value="model.FullName" Label="ФИО" Class="mb-3 w-100" />
+                    <MudNumericField T="int" @bind-Value="model.DepartmentId" Label="ID отдела" Class="mb-3 w-100" />
+                    <MudTextField @bind-Value="roles" Label="Роли (через запятую)" Class="mb-3 w-100" />
+                </MudTabPanel>
+                <MudTabPanel Text="Дополнительно">
                     <!-- дополнительные поля -->
-                </ContentTemplate>
-</TabItem>
-            </TabItems>
-        </SfTab>
-        <div class="text-right mt-3">
-            <SfButton Type="Submit" CssClass="e-primary me-2">Сохранить</SfButton>
-            <SfButton CssClass="e-flat" OnClick="@( (MouseEventArgs e) => dlg.HideAsync() )">Отмена</SfButton>
-        </div>
-    </EditForm>
-</SfDialog>
+                </MudTabPanel>
+            </MudTabs>
+            <div class="text-right mt-3">
+                <MudButton Type="Submit" Color="Color.Primary" Class="me-2">Сохранить</MudButton>
+                <MudButton Variant="Variant.Text" OnClick="Hide">Отмена</MudButton>
+            </div>
+        </EditForm>
+    </DialogContent>
+</MudDialog>
 
 @code {
-    SfDialog dlg;
+    bool open;
     CreateUserDto model = new();
     bool isNew;
     string hdr;
@@ -50,7 +41,7 @@
         model = new CreateUserDto { RoleIds = new List<string>() };
         hdr = "Новый пользователь";
         isNew = true;
-        _ = dlg.ShowAsync();
+        open = true;
     }
 
     public async void Load(string userId)
@@ -61,7 +52,7 @@
         model = new CreateUserDto { Email = u.Email, FullName = u.FullName, DepartmentId = 0, RoleIds = u.Roles };
         hdr = "Редактировать пользователя";
         isNew = false;
-        _ = dlg.ShowAsync();
+        open = true;
     }
 
     async Task Save()
@@ -76,12 +67,14 @@
         {
             await ApiClient.UpdateAsync(id, new UpdateUserDto { FullName = model.FullName, DepartmentId = model.DepartmentId, RoleIds = list });
         }
-        _ = dlg.HideAsync();
+        Hide();
         if (OnSaved.HasDelegate)
         {
             await OnSaved.InvokeAsync();
         }
     }
+
+    void Hide() => open = false;
 
     [Parameter] public EventCallback OnSaved { get; set; }
 }

--- a/Client.Wasm/Client.Wasm/Pages/Users.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Users.razor
@@ -5,35 +5,36 @@
 @inject IJSRuntime Js
 @inject NavigationManager NavigationManager
 
-<div class="container p-4">
-    <SfCard CssClass="mb-4">
-        <CardHeader>
-            <h1>Пользователи</h1>
-        </CardHeader>
-        <CardContent>
-            <SfButton CssClass="e-primary mb-3" IconCss="e-icons e-add" OnClick="@( (MouseEventArgs e) => edit.Show(new CreateUserDto()) )">Добавить пользователя</SfButton>
-            <SfGrid TItem="UserDto" DataSource="@items" AllowPaging="true" Width="100%" CssClass="e-bootstrap5">
-            <GridColumns>
-                <GridColumn Field=@nameof(UserDto.Id) HeaderText="ID" Width="120" />
-                <GridColumn Field=@nameof(UserDto.Email) HeaderText="Email" Width="200" />
-            <GridColumn Field=@nameof(UserDto.FullName) HeaderText="ФИО" Width="200" />
-            <GridColumn HeaderText="Роли" Width="200">
-                <Template>
-                    @string.Join(", ", (context as UserDto).Roles)
-                </Template>
-            </GridColumn>
-            <GridColumn HeaderText="Действия" TextAlign="TextAlign.Center" Width="150">
-                <Template>
-                    <SfButton CssClass="e-flat" IconCss="e-icons e-edit" OnClick="@( (MouseEventArgs e) => edit.Load((context as UserDto).Id) )" />
-                    <SfButton CssClass="e-flat e-danger" IconCss="e-icons e-delete" OnClick="@( (MouseEventArgs e) => Delete((context as UserDto).Id) )" />
-                </Template>
-            </GridColumn>
-            </GridColumns>
-        </SfGrid>
-        </CardContent>
-    </SfCard>
+<MudContainer MaxWidth="MaxWidth.False" Class="p-4">
+    <MudCard Class="mb-4">
+        <MudCardHeader>
+            <MudText Typo="Typo.h5">Пользователи</MudText>
+        </MudCardHeader>
+        <MudCardContent>
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" Class="mb-3" OnClick="@(()=> edit.Show(new CreateUserDto()))">Добавить пользователя</MudButton>
+            <MudTable Items="@items" Hover="true" Dense="true">
+                <HeaderContent>
+                    <MudTh>ID</MudTh>
+                    <MudTh>Email</MudTh>
+                    <MudTh>ФИО</MudTh>
+                    <MudTh>Роли</MudTh>
+                    <MudTh Class="text-center">Действия</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="ID">@context.Id</MudTd>
+                    <MudTd DataLabel="Email">@context.Email</MudTd>
+                    <MudTd DataLabel="ФИО">@context.FullName</MudTd>
+                    <MudTd DataLabel="Роли">@string.Join(", ", context.Roles)</MudTd>
+                    <MudTd Class="text-center" DataLabel="Действия">
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit" OnClick="@(()=> edit.Load(context.Id))" />
+                        <MudIconButton Color="Color.Error" Icon="@Icons.Material.Filled.Delete" OnClick="@(()=> Delete(context.Id))" />
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+        </MudCardContent>
+    </MudCard>
     <UserEdit @ref="edit" OnSaved="LoadData" />
-</div>
+</MudContainer>
 
 @code {
     List<UserDto> items = new();


### PR DESCRIPTION
## Summary
- remove Syncfusion components from Users pages
- port Users and UserEdit dialogs to MudBlazor
- ensure MudBlazor is imported via _Imports.razor

## Testing
- `dotnet build GovServicesSolution.sln` *(fails: missing MudBlazor replacements on other pages)*

------
https://chatgpt.com/codex/tasks/task_e_685a4445a91083239dbcd8687cb8ec43