### PR TITLE
Replace Syncfusion dialogs

### DIFF
--- a/Client.Wasm/Client.Wasm/Pages/ApplicationEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/ApplicationEdit.razor
@@ -4,39 +4,30 @@
 @inject NavigationManager NavigationManager
 @inject IApplicationApiClient ApiClient
 
-<SfDialog @ref="dlg" Width="450px" ShowCloseIcon="true" Header="@header">
-    <EditForm Model="model" OnValidSubmit="Save">
-        <DataAnnotationsValidator />
-        <SfTab>
-            <TabItems>
-                <TabItem>
-    <ChildContent>
-        <TabHeader Text="Основное"></TabHeader>
-    </ChildContent>
-    <ContentTemplate>
-                    <SfNumericTextBox TValue="int" @bind-Value="model.ServiceId" Placeholder="ID услуги" CssClass="mb-3 w-100" />
-                    <SfTextBox TValue="string" Multiline="true" @bind-Value="formData" Placeholder="Данные формы (JSON)" CssClass="mb-3 w-100" Rows="4" />
-                </ContentTemplate>
-</TabItem>
-                <TabItem>
-    <ChildContent>
-        <TabHeader Text="Дополнительно"></TabHeader>
-    </ChildContent>
-    <ContentTemplate>
+<MudDialog @bind-Visible="open" MaxWidth="MaxWidth.Small">
+    <DialogContent>
+        <MudText Typo="Typo.h6" Class="mb-2">@header</MudText>
+        <EditForm Model="model" OnValidSubmit="Save">
+            <DataAnnotationsValidator />
+            <MudTabs>
+                <MudTabPanel Text="Основное">
+                    <MudNumericField T="int" @bind-Value="model.ServiceId" Label="ID услуги" Class="mb-3 w-100" />
+                    <MudTextField Lines="4" @bind-Value="formData" Label="Данные формы (JSON)" Class="mb-3 w-100" />
+                </MudTabPanel>
+                <MudTabPanel Text="Дополнительно">
                     <!-- дополнительные поля -->
-                </ContentTemplate>
-</TabItem>
-            </TabItems>
-        </SfTab>
-        <div class="text-right mt-3">
-            <SfButton Type="Submit" CssClass="e-primary me-2">Сохранить</SfButton>
-            <SfButton CssClass="e-flat" OnClick="@( (MouseEventArgs e) => dlg.HideAsync() )">Отмена</SfButton>
-        </div>
-    </EditForm>
-</SfDialog>
+                </MudTabPanel>
+            </MudTabs>
+            <div class="text-right mt-3">
+                <MudButton Type="Submit" Color="Color.Primary" Class="me-2">Сохранить</MudButton>
+                <MudButton Variant="Variant.Text" OnClick="Hide">Отмена</MudButton>
+            </div>
+        </EditForm>
+    </DialogContent>
+</MudDialog>
 
 @code {
-    SfDialog dlg;
+    bool open;
     CreateApplicationDto model = new();
     UpdateApplicationDto updateModel = new();
     bool isNew;
@@ -50,7 +41,7 @@
         formData = "{}";
         header = "Новая заявка";
         isNew = true;
-        _ = dlg.ShowAsync();
+        open = true;
     }
 
     public async void Load(int id)
@@ -60,7 +51,7 @@
         updateModel = new UpdateApplicationDto { CurrentStepId = app.CurrentStepId, Status = app.Status, AssignedToUserId = app.AssignedToUserId };
         header = $"Редактировать заявку #{id}";
         isNew = false;
-        _ = dlg.ShowAsync();
+        open = true;
     }
 
     async Task Save()
@@ -69,12 +60,14 @@
             await ApiClient.CreateAsync(new CreateApplicationDto { ServiceId = model.ServiceId, FormData = new Dictionary<string, object>() });
         else
             await ApiClient.UpdateAsync(editId, updateModel);
-        _ = dlg.HideAsync();
+        Hide();
         if (OnSaved.HasDelegate)
         {
             await OnSaved.InvokeAsync();
         }
     }
+
+    void Hide() => open = false;
 
     [Parameter] public EventCallback OnSaved { get; set; }
 }

--- a/Client.Wasm/Client.Wasm/Pages/TemplateEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/TemplateEdit.razor
@@ -4,40 +4,31 @@
 @inject NavigationManager NavigationManager
 @inject ITemplateApiClient ApiClient
 
-<SfDialog @ref="dlg" Width="450px" ShowCloseIcon="true" Header="@hdr">
-    <EditForm Model="model" OnValidSubmit="Save">
-        <DataAnnotationsValidator />
-        <SfTab>
-            <TabItems>
-                <TabItem>
-    <ChildContent>
-        <TabHeader Text="Основное"></TabHeader>
-    </ChildContent>
-    <ContentTemplate>
-                    <SfTextBox TValue="string" @bind-Value="model.Name" Placeholder="Название" CssClass="mb-3 w-100" />
-                    <SfTextBox TValue="string" @bind-Value="model.Type" Placeholder="Тип" CssClass="mb-3 w-100" />
-                    <SfTextBox TValue="string" Multiline="true" @bind-Value="model.Content" Placeholder="Содержимое" CssClass="mb-3 w-100" Rows="6" />
-                </ContentTemplate>
-</TabItem>
-                <TabItem>
-    <ChildContent>
-        <TabHeader Text="Дополнительно"></TabHeader>
-    </ChildContent>
-    <ContentTemplate>
+<MudDialog @bind-Visible="open" MaxWidth="MaxWidth.Small">
+    <DialogContent>
+        <MudText Typo="Typo.h6" Class="mb-2">@hdr</MudText>
+        <EditForm Model="model" OnValidSubmit="Save">
+            <DataAnnotationsValidator />
+            <MudTabs>
+                <MudTabPanel Text="Основное">
+                    <MudTextField @bind-Value="model.Name" Label="Название" Class="mb-3 w-100" />
+                    <MudTextField @bind-Value="model.Type" Label="Тип" Class="mb-3 w-100" />
+                    <MudTextField Lines="6" @bind-Value="model.Content" Label="Содержимое" Class="mb-3 w-100" />
+                </MudTabPanel>
+                <MudTabPanel Text="Дополнительно">
                     <!-- дополнительные поля -->
-                </ContentTemplate>
-</TabItem>
-            </TabItems>
-        </SfTab>
-        <div class="text-right mt-3">
-            <SfButton Type="Submit" CssClass="e-primary me-2">Сохранить</SfButton>
-            <SfButton CssClass="e-flat" OnClick="@( (MouseEventArgs e) => dlg.HideAsync() )">Отмена</SfButton>
-        </div>
-    </EditForm>
-</SfDialog>
+                </MudTabPanel>
+            </MudTabs>
+            <div class="text-right mt-3">
+                <MudButton Type="Submit" Color="Color.Primary" Class="me-2">Сохранить</MudButton>
+                <MudButton Variant="Variant.Text" OnClick="Hide">Отмена</MudButton>
+            </div>
+        </EditForm>
+    </DialogContent>
+</MudDialog>
 
 @code {
-    SfDialog dlg;
+    bool open;
     TemplateDto model = new();
     bool isNew;
     int editId;
@@ -48,7 +39,7 @@
         model = new TemplateDto();
         hdr = "Новый шаблон";
         isNew = true;
-        _ = dlg.ShowAsync();
+        open = true;
     }
 
     public async void Load(int id)
@@ -58,7 +49,7 @@
         editId = id;
         hdr = $"Редактировать шаблон #{id}";
         isNew = false;
-        _ = dlg.ShowAsync();
+        open = true;
     }
 
     async Task Save()
@@ -67,12 +58,14 @@
             await ApiClient.CreateAsync(new CreateTemplateDto { Name = model.Name, Type = model.Type, Content = model.Content });
         else
             await ApiClient.UpdateAsync(editId, new UpdateTemplateDto { Name = model.Name, Type = model.Type, Content = model.Content });
-        _ = dlg.HideAsync();
+        Hide();
         if (OnSaved.HasDelegate)
         {
             await OnSaved.InvokeAsync();
         }
     }
+
+    void Hide() => open = false;
 
     [Parameter] public EventCallback OnSaved { get; set; }
 }


### PR DESCRIPTION
## Summary
- migrate ApplicationEdit to MudBlazor dialog
- migrate TemplateEdit to MudBlazor dialog

## Testing
- `dotnet build GovServicesSolution.sln` *(fails: PointEventArgs & other Syncfusion references)*

------
https://chatgpt.com/codex/tasks/task_e_685a5b03a49883239cfe1ced22223480