### PR TITLE
Remove syncfusion from first pages

### DIFF
--- a/Client.Wasm/Client.Wasm/Pages/Counter.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Counter.razor
@@ -2,15 +2,15 @@
 @page "/counter"
 
 <div class="container p-4">
-    <SfCard CssClass="mb-4">
-        <CardHeader>
-            <h1>Счётчик</h1>
-        </CardHeader>
-        <CardContent>
+    <MudCard Class="mb-4">
+        <MudCardHeader>
+            <MudText Typo="Typo.h5">Счётчик</MudText>
+        </MudCardHeader>
+        <MudCardContent>
             <p class="mb-3">Текущее значение: @currentCount</p>
-            <SfButton CssClass="e-primary" OnClick="IncrementCount">Увеличить</SfButton>
-        </CardContent>
-    </SfCard>
+            <MudButton Color="Color.Primary" OnClick="IncrementCount">Увеличить</MudButton>
+        </MudCardContent>
+    </MudCard>
 </div>
 
 @code {

--- a/Client.Wasm/Client.Wasm/Pages/DictionaryUpload.razor
+++ b/Client.Wasm/Client.Wasm/Pages/DictionaryUpload.razor
@@ -2,30 +2,33 @@
 @using Microsoft.AspNetCore.Components.Forms
 @inject IDictionaryApiClient ApiClient
 
-<SfDialog @ref="dlg" Width="450px" ShowCloseIcon="true" Header="Загрузить справочник">
-    <EditForm Model="model" OnValidSubmit="HandleSave">
-        <DataAnnotationsValidator />
-        <SfTextBox TValue="string" @bind-Value="model.Name" Placeholder="Название" CssClass="mb-3 w-100" />
-        <SfTextBox TValue="string" @bind-Value="model.Description" Placeholder="Описание" CssClass="mb-3 w-100" />
-        <InputFile OnChange="OnFileSelected" class="mb-3" />
-        <div class="text-right mt-3">
-            <SfButton Type="Submit" CssClass="e-primary me-2">Сохранить</SfButton>
-            <SfButton CssClass="e-flat" OnClick="Hide">Отмена</SfButton>
-        </div>
-    </EditForm>
-</SfDialog>
+<MudDialog @bind-Visible="open" MaxWidth="MaxWidth.Small">
+    <DialogContent>
+        <MudText Typo="Typo.h6" Class="mb-2">Загрузить справочник</MudText>
+        <EditForm Model="model" OnValidSubmit="HandleSave">
+            <DataAnnotationsValidator />
+            <MudTextField @bind-Value="model.Name" Label="Название" Class="mb-3 w-100" />
+            <MudTextField @bind-Value="model.Description" Label="Описание" Class="mb-3 w-100" />
+            <InputFile OnChange="OnFileSelected" class="mb-3" />
+            <div class="text-right mt-3">
+                <MudButton Type="Submit" Color="Color.Primary" Class="me-2">Сохранить</MudButton>
+                <MudButton Variant="Variant.Text" OnClick="Hide">Отмена</MudButton>
+            </div>
+        </EditForm>
+    </DialogContent>
+</MudDialog>
 
 @code {
-    SfDialog? dlg;
+    bool open;
     UploadDictionaryDto model = new();
 
     public void Show()
     {
         model = new UploadDictionaryDto();
-        _ = dlg!.ShowAsync();
+        open = true;
     }
 
-    Task Hide() => dlg!.HideAsync();
+    void Hide() => open = false;
 
     void OnFileSelected(InputFileChangeEventArgs e)
     {
@@ -36,7 +39,7 @@
     async Task HandleSave()
     {
         await ApiClient.UploadAsync(model);
-        await dlg!.HideAsync();
+        Hide();
         if (OnUploaded.HasDelegate) await OnUploaded.InvokeAsync();
     }
 


### PR DESCRIPTION
## Summary
- replace Syncfusion components with MudBlazor in Counter page
- replace Syncfusion dialog with MudDialog in DictionaryUpload page

## Testing
- `dotnet build GovServicesSolution.sln` *(fails: DropDownMenuItem, SfDialog etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685a60759bf88323966d60460a20bc5b