### PR TITLE
Replace Syncfusion controls on Profile page

### DIFF
--- a/Client.Wasm/Client.Wasm/Pages/Profile.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Profile.razor
@@ -4,36 +4,31 @@
 @using Client.Wasm.DTOs
 @inject IJSRuntime Js
 @inject NavigationManager NavigationManager
+@inject ISnackbar Snackbar
 <div class="container p-4">
-    <SfCard CssClass="mb-4">
-        <CardHeader>
-            <h1>Профиль</h1>
-        </CardHeader>
-        <CardContent>
+    <MudCard Class="mb-4">
+        <MudCardHeader>
+            <MudText Typo="Typo.h5">Профиль</MudText>
+        </MudCardHeader>
+        <MudCardContent>
             <EditForm Model="model" OnValidSubmit="OnSave">
                 <DataAnnotationsValidator />
                 <ValidationSummary />
-                <SfTextBox TValue="string" @bind-Value="model.FullName" Placeholder="ФИО" CssClass="mb-3 w-100" />
-                <SfTextBox TValue="string" @bind-Value="model.Email" Placeholder="Email" CssClass="mb-3 w-100" />
-                <SfButton Type="Submit" CssClass="e-primary">Сохранить</SfButton>
+                <MudTextField @bind-Value="model.FullName" Placeholder="ФИО" Class="mb-3 w-100" />
+                <MudTextField @bind-Value="model.Email" Placeholder="Email" Class="mb-3 w-100" />
+                <MudButton Type="Submit" Color="Color.Primary">Сохранить</MudButton>
             </EditForm>
-        </CardContent>
-    </SfCard>
+        </MudCardContent>
+    </MudCard>
 </div>
-
-<SfToast @ref="toast" Timeout="3000"></SfToast>
 
 @code {
     ProfileModel model = new();
-    SfToast? toast;
 
     async Task OnSave()
     {
         // TODO: реализовать логику сохранения профиля
-        if (toast != null)
-        {
-            await toast.ShowAsync(new ToastModel { Content = "Профиль сохранён" });
-        }
+        Snackbar.Add("Профиль сохранён", Severity.Success);
     }
 
     class ProfileModel


### PR DESCRIPTION
## Summary
- swap Syncfusion controls for MudBlazor on `Profile.razor`
- use `ISnackbar` for notification
- remove unused Syncfusion toast

## Testing
- `dotnet restore GovServicesSolution.sln`
- `dotnet build GovServicesSolution.sln --no-restore` *(fails: missing many Syncfusion controls)*

------
https://chatgpt.com/codex/tasks/task_e_685a618431308323ac34bba439913fbb