### PR TITLE
Replace Syncfusion controls with MudBlazor

### DIFF
--- a/Client.Wasm/Client.Wasm/Pages/ChangePassword.razor
+++ b/Client.Wasm/Client.Wasm/Pages/ChangePassword.razor
@@ -6,19 +6,19 @@
 @inject NavigationManager NavigationManager
 
 <div class="container p-4">
-    <SfCard CssClass="mb-4">
-        <CardHeader>
-            <h1>Смена пароля</h1>
-        </CardHeader>
-        <CardContent>
+    <MudCard Class="mb-4">
+        <MudCardHeader>
+            <MudText Typo="Typo.h6">Смена пароля</MudText>
+        </MudCardHeader>
+        <MudCardContent>
             <EditForm Model="model" OnValidSubmit="Save">
                 <DataAnnotationsValidator />
-                <SfTextBox TValue="string" @bind-Value="model.OldPassword" Placeholder="Старый пароль" InputType="InputType.Password" CssClass="mb-3 w-100" />
-                <SfTextBox TValue="string" @bind-Value="model.NewPassword" Placeholder="Новый пароль" InputType="InputType.Password" CssClass="mb-3 w-100" />
-                <SfButton Type="Submit" CssClass="e-primary">Сохранить</SfButton>
+                <MudTextField @bind-Value="model.OldPassword" Label="Старый пароль" InputType="InputType.Password" Class="mb-3 w-100" />
+                <MudTextField @bind-Value="model.NewPassword" Label="Новый пароль" InputType="InputType.Password" Class="mb-3 w-100" />
+                <MudButton Type="Submit" Color="Color.Primary">Сохранить</MudButton>
             </EditForm>
-        </CardContent>
-    </SfCard>
+        </MudCardContent>
+    </MudCard>
 </div>
 
 @code {

--- a/Client.Wasm/Client.Wasm/Pages/Permissions.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Permissions.razor
@@ -2,40 +2,33 @@
 @inject IPermissionApiClient ApiClient
 @using Client.Wasm.DTOs
 
-<SfCard CssClass="mb-4">
-    <CardHeader>
-        <h2>Права доступа</h2>
-    </CardHeader>
-    <CardContent>
-        <SfGrid TValue="PermissionDto" DataSource="@items" AllowPaging="true" CssClass="e-bootstrap5">
-            <GridColumns>
-                <GridColumn Field="Role" HeaderText="Роль" Width="150" />
-                <GridColumn Field="ServiceId" HeaderText="Услуга" Width="120" />
-                <GridColumn Field="DepartmentId" HeaderText="Отдел" Width="120" />
-                <GridColumn HeaderText="Просмотр" TextAlign="TextAlign.Center" Width="80">
-                    <Template>
-                        @((context as PermissionDto).CanView ? "✓" : "-")
-                    </Template>
-                </GridColumn>
-                <GridColumn HeaderText="Изменение" TextAlign="TextAlign.Center" Width="80">
-                    <Template>
-                        @((context as PermissionDto).CanEdit ? "✓" : "-")
-                    </Template>
-                </GridColumn>
-                <GridColumn HeaderText="Утверждение" TextAlign="TextAlign.Center" Width="80">
-                    <Template>
-                        @((context as PermissionDto).CanApprove ? "✓" : "-")
-                    </Template>
-                </GridColumn>
-                <GridColumn HeaderText="Удаление" TextAlign="TextAlign.Center" Width="80">
-                    <Template>
-                        @((context as PermissionDto).CanDelete ? "✓" : "-")
-                    </Template>
-                </GridColumn>
-            </GridColumns>
-        </SfGrid>
-    </CardContent>
-</SfCard>
+<MudCard Class="mb-4">
+    <MudCardHeader>
+        <MudText Typo="Typo.h6">Права доступа</MudText>
+    </MudCardHeader>
+    <MudCardContent>
+        <MudTable Items="@items" Hover="true" Dense="true">
+            <HeaderContent>
+                <MudTh>Роль</MudTh>
+                <MudTh>Услуга</MudTh>
+                <MudTh>Отдел</MudTh>
+                <MudTh Class="text-center">Просмотр</MudTh>
+                <MudTh Class="text-center">Изменение</MudTh>
+                <MudTh Class="text-center">Утверждение</MudTh>
+                <MudTh Class="text-center">Удаление</MudTh>
+            </HeaderContent>
+            <RowTemplate Context="item">
+                <MudTd DataLabel="Роль">@item.Role</MudTd>
+                <MudTd DataLabel="Услуга">@item.ServiceId</MudTd>
+                <MudTd DataLabel="Отдел">@item.DepartmentId</MudTd>
+                <MudTd Class="text-center" DataLabel="Просмотр">@((item.CanView) ? "✓" : "-")</MudTd>
+                <MudTd Class="text-center" DataLabel="Изменение">@((item.CanEdit) ? "✓" : "-")</MudTd>
+                <MudTd Class="text-center" DataLabel="Утверждение">@((item.CanApprove) ? "✓" : "-")</MudTd>
+                <MudTd Class="text-center" DataLabel="Удаление">@((item.CanDelete) ? "✓" : "-")</MudTd>
+            </RowTemplate>
+        </MudTable>
+    </MudCardContent>
+</MudCard>
 
 @code {
     List<PermissionDto> items = new();


### PR DESCRIPTION
## Summary
- swap Syncfusion components for MudBlazor in `ChangePassword.razor` and `Permissions.razor`
- project already registers MudBlazor services and namespaces

## Testing
- `dotnet build GovServicesSolution.sln` *(fails: CS0246 errors in remaining pages using Syncfusion)*

------
https://chatgpt.com/codex/tasks/task_e_685a65d9610c8323bdf420fa0514ccd3