### PR TITLE
Replace Syncfusion Weather page with MudBlazor

### DIFF
--- a/Client.Wasm/Client.Wasm/Pages/Weather.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Weather.razor
@@ -4,28 +4,34 @@
 @using Client.Wasm.Helpers
 
 <div class="container p-4">
-    <SfCard CssClass="mb-4">
-        <CardHeader>
-            <h1>Погода</h1>
-        </CardHeader>
-        <CardContent>
+    <MudCard Class="mb-4">
+        <MudCardHeader>
+            <MudText Typo="Typo.h6">Погода</MudText>
+        </MudCardHeader>
+        <MudCardContent>
             @if (forecasts == null)
             {
                 <p><em>Loading...</em></p>
             }
             else
             {
-                <SfGrid DataSource="forecasts" Width="100%" CssClass="e-bootstrap5">
-                <GridColumns>
-                    <GridColumn Field=@nameof(WeatherForecast.Date) HeaderText="Дата" Format="d" Width="120" />
-                    <GridColumn Field=@nameof(WeatherForecast.TemperatureC) HeaderText="C" Width="100" />
-                    <GridColumn Field=@nameof(WeatherForecast.TemperatureF) HeaderText="F" Width="100" />
-                    <GridColumn Field=@nameof(WeatherForecast.Summary) HeaderText="Описание" Width="*" />
-                </GridColumns>
-                </SfGrid>
+                <MudTable Items="forecasts" Dense="true" Hover="true" Class="w-100">
+                    <HeaderContent>
+                        <MudTh>Date</MudTh>
+                        <MudTh>C</MudTh>
+                        <MudTh>F</MudTh>
+                        <MudTh>Описание</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Дата">@context.Date.ToShortDateString()</MudTd>
+                        <MudTd DataLabel="C">@context.TemperatureC</MudTd>
+                        <MudTd DataLabel="F">@context.TemperatureF</MudTd>
+                        <MudTd DataLabel="Описание">@context.Summary</MudTd>
+                    </RowTemplate>
+                </MudTable>
             }
-        </CardContent>
-    </SfCard>
+        </MudCardContent>
+    </MudCard>
 </div>
 
 @code {


### PR DESCRIPTION
## Summary
- install .NET 8 SDK for building the solution
- replace `SfCard` and `SfGrid` on Weather page with MudBlazor `MudCard` and `MudTable`

## Testing
- `dotnet build GovServicesSolution.sln` *(fails: MenuItem and SfDialog types missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a70fecd908323a2af8a5dc3c3c271