### PR TITLE
Replace Syncfusion in navigation

### DIFF
--- a/Client.Wasm/Client.Wasm/Components/TopNav.razor
+++ b/Client.Wasm/Client.Wasm/Components/TopNav.razor
@@ -1,130 +1,64 @@
 @inject NavigationManager Nav
-@inject AuthenticationStateProvider AuthProvider
 @inject IAuthService AuthService
 
 <AuthorizeView>
     <Authorized>
-        <SfAppBar CssClass="appbar e-appbar e-light">
-            <AppBarContent>
-                <div class="container d-flex align-items-center justify-content-between">
-                    <a href="/" class="d-flex align-items-center text-decoration-none me-4">
-                        <span class="h3 mb-0 me-2">🏛️</span>
-                        <span class="fw-semibold h5 mb-0">Государственные услуги</span>
-                    </a>
-                    <!-- Основное горизонтальное меню -->
-                    <SfMenu Items="@MenuItems"
-                             CssClass="bootstrap5 top-nav-menu"
-                             Orientation="Syncfusion.Blazor.Navigations.Orientation.Horizontal"
-                             ShowItemOnClick="true">
-                        <MenuEvents TValue="MenuItem" OnItemSelected="HandleMenuItemSelected" />
-                    </SfMenu>
-                    <!-- Меню пользователя в правом верхнем углу -->
-                    <SfDropDownButton CssClass="e-flat profile-button" IconCss="e-icons e-user" Items="UserItems" ItemSelected="OnUserItemSelected"></SfDropDownButton>
-                </div>
-            </AppBarContent>
-        </SfAppBar>
+        <MudAppBar Color="Color.Primary">
+            <MudToolbar>
+                <a href="/" class="d-flex align-items-center text-decoration-none me-4">
+                    <span class="h3 mb-0 me-2">🏛️</span>
+                    <span class="fw-semibold h5 mb-0">Государственные услуги</span>
+                </a>
+                <MudMenu Label="📄 Заявления" StartIcon="@Icons.Material.Filled.Description">
+                    <MudMenuItem Href="/applications">Все заявления</MudMenuItem>
+                    <MudMenuItem Href="/registry/applications">Реестр</MudMenuItem>
+                    <MudMenuItem Href="/registry/rdz-orders">РДЗ</MudMenuItem>
+                    <MudMenuItem Href="/registry/rdi-orders">РДИ</MudMenuItem>
+                </MudMenu>
+                <MudMenu Label="📑 Документы" StartIcon="@Icons.Material.Filled.Folder">
+                    <MudMenuItem Href="/registry/contracts">Договоры</MudMenuItem>
+                    <MudMenuItem Href="/registry/acts">Акты</MudMenuItem>
+                    <MudMenuItem Href="/registry/agreements">Соглашения</MudMenuItem>
+                </MudMenu>
+                <MudMenu Label="👤 Пользователи и роли" StartIcon="@Icons.Material.Filled.People">
+                    <MudMenuItem Href="/users">Список пользователей</MudMenuItem>
+                    <MudMenuItem Href="/roles">Роли и доступ</MudMenuItem>
+                </MudMenu>
+                <MudMenu Label="⚙️ Настройки" StartIcon="@Icons.Material.Filled.Settings">
+                    <MudMenuItem Href="/settings">Общие</MudMenuItem>
+                    <MudMenuItem Href="/settings/integrations">Интеграции</MudMenuItem>
+                </MudMenu>
+                <MudMenu Label="📊 Отчёты" StartIcon="@Icons.Material.Filled.BarChart">
+                    <MudMenuItem Href="/reports/stats">Статистика</MudMenuItem>
+                    <MudMenuItem Href="/reports/export">Выгрузки</MudMenuItem>
+                </MudMenu>
+                <MudMenu Label="🤖 ИИ" StartIcon="@Icons.Material.Filled.SmartToy">
+                    <MudMenuItem Href="/ai">Модель ИИ</MudMenuItem>
+                    <MudMenuItem Href="/ai/settings">Настройки ИИ</MudMenuItem>
+                </MudMenu>
+                <MudSpacer />
+                <MudMenu Icon="@Icons.Material.Filled.AccountCircle">
+                    <MudMenuItem OnClick="Profile">Настройки профиля</MudMenuItem>
+                    <MudMenuItem OnClick="Logout">Выход</MudMenuItem>
+                </MudMenu>
+            </MudToolbar>
+        </MudAppBar>
     </Authorized>
     <NotAuthorized>
-        <SfAppBar Color="AppBarColor.Light" CssClass="appbar">
-            <AppBarContent>
-                <div class="container d-flex justify-content-end align-items-center">
-                    <SfButton CssClass="e-primary" OnClick="@(() => Nav.NavigateTo("/login"))">Войти</SfButton>
-                </div>
-            </AppBarContent>
-        </SfAppBar>
+        <MudAppBar Color="Color.Primary">
+            <MudToolbar Class="justify-end">
+                <MudButton Color="Color.Primary" OnClick="@(() => Nav.NavigateTo("/login"))">Войти</MudButton>
+            </MudToolbar>
+        </MudAppBar>
     </NotAuthorized>
 </AuthorizeView>
 
 @code {
-    private List<MenuItem> MenuItems = new()
+    private async Task Logout()
     {
-        new MenuItem
-        {
-            Text = "📄 Заявления",
-            Items = new List<MenuItem>
-            {
-                new MenuItem{ Text = "Все заявления", Url = "/applications" },
-                new MenuItem{ Text = "Реестр", Url = "/registry/applications" },
-                new MenuItem{ Text = "РДЗ", Url = "/registry/rdz-orders" },
-                new MenuItem{ Text = "РДИ", Url = "/registry/rdi-orders" }
-            }
-        },
-        new MenuItem
-        {
-            Text = "📑 Документы",
-            Items = new List<MenuItem>
-            {
-                new MenuItem{ Text = "Договоры", Url = "/registry/contracts" },
-                new MenuItem{ Text = "Акты", Url = "/registry/acts" },
-                new MenuItem{ Text = "Соглашения", Url = "/registry/agreements" }
-            }
-        },
-        new MenuItem
-        {
-            Text = "👤 Пользователи и роли",
-            Items = new List<MenuItem>
-            {
-                new MenuItem{ Text = "Список пользователей", Url = "/users" },
-                new MenuItem{ Text = "Роли и доступ", Url = "/roles" }
-            }
-        },
-        new MenuItem
-        {
-            Text = "⚙️ Настройки",
-            Items = new List<MenuItem>
-            {
-                new MenuItem{ Text = "Общие", Url = "/settings" },
-                new MenuItem{ Text = "Интеграции", Url = "/settings/integrations" }
-            }
-        },
-        new MenuItem
-        {
-            Text = "📊 Отчёты",
-            Items = new List<MenuItem>
-            {
-                new MenuItem{ Text = "Статистика", Url = "/reports/stats" },
-                new MenuItem{ Text = "Выгрузки", Url = "/reports/export" }
-            }
-        },
-        new MenuItem
-        {
-            Text = "🤖 ИИ",
-            Items = new List<MenuItem>
-            {
-                new MenuItem{ Text = "Модель ИИ", Url = "/ai" },
-                new MenuItem{ Text = "Настройки ИИ", Url = "/ai/settings" }
-            }
-        }
-    };
-
-    private List<DropDownMenuItem> UserItems = new()
-    {
-        new DropDownMenuItem { Text = "Настройки профиля", Id = "profile" },
-        new DropDownMenuItem { Text = "Выход", Id = "logout" }
-    };
-
-    protected override Task OnInitializedAsync() => Task.CompletedTask;
-
-    private void HandleMenuItemSelected(MenuEventArgs<MenuItem> args)
-    {
-        Console.WriteLine(args.Item.Text);
-        if (!string.IsNullOrEmpty(args.Item.Url))
-        {
-            Nav.NavigateTo(args.Item.Url);
-        }
+        await AuthService.LogoutAsync();
+        Nav.NavigateTo("/login", true);
     }
 
-    private async Task OnUserItemSelected(MenuEventArgs<DropDownMenuItem> args)
-    {
-        switch (args.Item.Id)
-        {
-            case "logout":
-                await AuthService.LogoutAsync();
-                Nav.NavigateTo("/login", true);
-                break;
-            case "profile":
-                Nav.NavigateTo("/profile");
-                break;
-        }
-    }
+    private void Profile() => Nav.NavigateTo("/profile");
 }


### PR DESCRIPTION
## Summary
- remove Syncfusion AppBar/Menu from `TopNav`
- recreate navigation with MudBlazor components

## Testing
- `dotnet build GovServicesSolution.sln` *(fails: SfDialog and other missing references)*

------
https://chatgpt.com/codex/tasks/task_e_685a70fecd908323a2af8a5dc3c3c271