### PR TITLE
Replace Syncfusion in Workflows pages

### DIFF
--- a/Client.Wasm/Client.Wasm/Pages/WorkflowEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/WorkflowEdit.razor
@@ -4,39 +4,30 @@
 @inject NavigationManager NavigationManager
 @inject IWorkflowApiClient ApiClient
 
-<SfDialog @ref="dlg" Width="450px" ShowCloseIcon="true" Header="@hdr">
-    <EditForm Model="model" OnValidSubmit="Save">
-        <DataAnnotationsValidator />
-        <SfTab>
-            <TabItems>
-                <TabItem>
-    <ChildContent>
-        <TabHeader Text="Основное"></TabHeader>
-    </ChildContent>
-    <ContentTemplate>
-                    <SfTextBox TValue="string" @bind-Value="model.Name" Placeholder="Название" CssClass="mb-3 w-100" />
-                    <SfTextBox TValue="string" Multiline="true" @bind-Value="model.Description" Placeholder="Описание" CssClass="mb-3 w-100" Rows="4" />
-                </ContentTemplate>
-</TabItem>
-                <TabItem>
-    <ChildContent>
-        <TabHeader Text="Дополнительно"></TabHeader>
-    </ChildContent>
-    <ContentTemplate>
+<MudDialog @bind-Visible="open" MaxWidth="MaxWidth.Small" DisableBackdropClick="true">
+    <DialogContent>
+        <MudText Typo="Typo.h6" Class="mb-2">@hdr</MudText>
+        <EditForm Model="model" OnValidSubmit="Save">
+            <DataAnnotationsValidator />
+            <MudTabs>
+                <MudTabPanel Text="Основное">
+                    <MudTextField @bind-Value="model.Name" Label="Название" Class="mb-3 w-100" />
+                    <MudTextField @bind-Value="model.Description" Label="Описание" Class="mb-3 w-100" Lines="4" />
+                </MudTabPanel>
+                <MudTabPanel Text="Дополнительно">
                     <!-- дополнительные поля -->
-                </ContentTemplate>
-</TabItem>
-            </TabItems>
-        </SfTab>
-        <div class="text-right mt-3">
-            <SfButton Type="Submit" CssClass="e-primary me-2">Сохранить</SfButton>
-            <SfButton CssClass="e-flat" OnClick="@( (MouseEventArgs e) => dlg.HideAsync() )">Отмена</SfButton>
-        </div>
-    </EditForm>
-</SfDialog>
+                </MudTabPanel>
+            </MudTabs>
+            <div class="text-right mt-3">
+                <MudButton Type="Submit" Color="Color.Primary" Class="me-2">Сохранить</MudButton>
+                <MudButton Variant="Variant.Text" OnClick="Hide">Отмена</MudButton>
+            </div>
+        </EditForm>
+    </DialogContent>
+</MudDialog>
 
 @code {
-    SfDialog dlg;
+    bool open;
     WorkflowDto model = new();
     string hdr;
     bool isNew;
@@ -46,7 +37,7 @@
         model = new WorkflowDto();
         hdr = "Новый маршрут";
         isNew = true;
-        _ = dlg.ShowAsync();
+        open = true;
     }
 
     public async void Load(int id)
@@ -54,7 +45,7 @@
         model = await ApiClient.GetByIdAsync(id);
         hdr = $"Редактировать маршрут #{id}";
         isNew = false;
-        _ = dlg.ShowAsync();
+        open = true;
     }
 
     async Task Save()
@@ -63,12 +54,14 @@
             await ApiClient.CreateAsync(model);
         else
             await ApiClient.UpdateAsync(model);
-        _ = dlg.HideAsync();
+        Hide();
         if (OnSaved.HasDelegate)
         {
             await OnSaved.InvokeAsync();
         }
     }
+
+    void Hide() => open = false;
 
     [Parameter] public EventCallback OnSaved { get; set; }
 }

--- a/Client.Wasm/Client.Wasm/Pages/Workflows.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Workflows.razor
@@ -6,29 +6,32 @@
 @inject NavigationManager NavigationManager
 
 <div class="container p-4">
-    <SfCard CssClass="mb-4">
-        <CardHeader>
-            <h1>Маршруты</h1>
-        </CardHeader>
-        <CardContent>
-            <SfButton CssClass="e-primary mb-3" IconCss="e-icons e-add" OnClick="@( (MouseEventArgs e) => edit.Show() )">Новый маршрут</SfButton>
-            <SfGrid TItem="WorkflowDto" DataSource="@items" AllowPaging="true" Width="100%" CssClass="e-bootstrap5">
-            <GridPageSettings PageSize="10" />
-            <GridColumns>
-                <GridColumn Field=@nameof(WorkflowDto.Id) HeaderText="ID" Width="70" TextAlign="TextAlign.Center" IsPrimaryKey="true" />
-            <GridColumn Field=@nameof(WorkflowDto.Name) HeaderText="Название" Width="*"/>
-            <GridColumn Field=@nameof(WorkflowDto.Description) HeaderText="Описание" Width="2*"/>
-            <GridColumn HeaderText="Действия" TextAlign="TextAlign.Center" Width="150">
-                <Template>
-                    <SfButton CssClass="e-flat" IconCss="e-icons e-edit" OnClick="@( (MouseEventArgs e) => edit.Load((context as WorkflowDto).Id) )" />
-                    <SfButton CssClass="e-flat e-danger" IconCss="e-icons e-delete" OnClick="@( (MouseEventArgs e) => Delete((context as WorkflowDto).Id) )" />
-                </Template>
-            </GridColumn>
-            </GridColumns>
-        </SfGrid>
-        </CardContent>
-    </SfCard>
-    <WorkflowEdit @ref="edit" OnSaved="LoadData"/>
+    <MudCard Class="mb-4">
+        <MudCardHeader>
+            <MudText Typo="Typo.h5">Маршруты</MudText>
+        </MudCardHeader>
+        <MudCardContent>
+            <MudButton Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add" Class="mb-3" OnClick="@(()=> edit.Show())">Новый маршрут</MudButton>
+            <MudTable Items="@items" Hover="true" Dense="true" RowsPerPage="10">
+                <HeaderContent>
+                    <MudTh>ID</MudTh>
+                    <MudTh>Название</MudTh>
+                    <MudTh>Описание</MudTh>
+                    <MudTh Class="text-center">Действия</MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="ID">@context.Id</MudTd>
+                    <MudTd DataLabel="Название">@context.Name</MudTd>
+                    <MudTd DataLabel="Описание">@context.Description</MudTd>
+                    <MudTd DataLabel="Действия" Class="text-center">
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit" OnClick="@(()=> edit.Load(context.Id))" />
+                        <MudIconButton Color="Color.Error" Icon="@Icons.Material.Filled.Delete" OnClick="@(()=> Delete(context.Id))" />
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+        </MudCardContent>
+    </MudCard>
+    <WorkflowEdit @ref="edit" OnSaved="LoadData" />
 </div>
 
 @code {


### PR DESCRIPTION
## Summary
- replace Syncfusion components in `Workflows.razor` with MudBlazor
- replace Syncfusion components in `WorkflowEdit.razor` with MudBlazor
- ensure MudBlazor services are registered

## Testing
- `dotnet build GovServicesSolution.sln` *(fails: CS0246, missing SfDialog et al.)*


------
https://chatgpt.com/codex/tasks/task_e_685a72caa6f4832384a4fb398a476ad4