### PR TITLE
Replace Syncfusion in number template pages

### DIFF
--- a/Client.Wasm/Client.Wasm/Pages/NumberTemplateEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/NumberTemplateEdit.razor
@@ -2,30 +2,38 @@
 @using Client.Wasm.DTOs
 @inject INumberTemplateApiClient ApiClient
 
-<SfDialog @ref="dlg" Width="450px" ShowCloseIcon="true" Header="@header">
-    <EditForm Model="model" OnValidSubmit="Save">
-        <DataAnnotationsValidator />
-        <div class="mb-3">
-            <SfTextBox TValue="string" @bind-Value="model.Name" Placeholder="Название" CssClass="w-100" />
-        </div>
-        <div class="mb-3">
-            <SfTextBox TValue="string" @bind-Value="model.TargetType" Placeholder="Тип" CssClass="w-100" />
-        </div>
-        <div class="mb-3">
-            <SfTextBox TValue="string" @bind-Value="model.TemplateText" Placeholder="Шаблон" CssClass="w-100" />
-        </div>
-        <div class="mb-3">
-            <SfDropDownList TItem="ResetPolicy" TValue="ResetPolicy" DataSource="resetOptions" @bind-Value="model.ResetPolicy" Placeholder="Политика сброса" />
-        </div>
-        <div class="text-right mt-3">
-            <SfButton Type="Submit" CssClass="e-primary me-2">Сохранить</SfButton>
-            <SfButton CssClass="e-flat" OnClick="Hide">Отмена</SfButton>
-        </div>
-    </EditForm>
-</SfDialog>
+<MudDialog @bind-Visible="open" MaxWidth="MaxWidth.Small">
+    <DialogContent>
+        <MudDialogTitle>@header</MudDialogTitle>
+        <EditForm Model="model" OnValidSubmit="Save">
+            <DataAnnotationsValidator />
+            <div class="mb-3">
+                <MudTextField @bind-Value="model.Name" Label="Название" Class="w-100" />
+            </div>
+            <div class="mb-3">
+                <MudTextField @bind-Value="model.TargetType" Label="Тип" Class="w-100" />
+            </div>
+            <div class="mb-3">
+                <MudTextField @bind-Value="model.TemplateText" Label="Шаблон" Class="w-100" />
+            </div>
+            <div class="mb-3">
+                <MudSelect T="ResetPolicy" @bind-Value="model.ResetPolicy" Label="Политика сброса" Class="w-100">
+                    @foreach (var option in resetOptions)
+                    {
+                        <MudSelectItem Value="@option">@option</MudSelectItem>
+                    }
+                </MudSelect>
+            </div>
+            <div class="text-right mt-3">
+                <MudButton Type="Submit" Color="Color.Primary" Class="me-2">Сохранить</MudButton>
+                <MudButton Variant="Variant.Text" OnClick="Hide">Отмена</MudButton>
+            </div>
+        </EditForm>
+    </DialogContent>
+</MudDialog>
 
 @code {
-    SfDialog dlg;
+    bool open;
     string header = string.Empty;
     bool isNew;
     NumberTemplateDto model = new();
@@ -36,7 +44,7 @@
         model = new NumberTemplateDto();
         header = "Новый шаблон";
         isNew = true;
-        _ = dlg.ShowAsync();
+        open = true;
     }
 
     public async void Load(int id)
@@ -45,10 +53,10 @@
         if (t != null) model = t;
         header = $"Редактировать {t?.Name}";
         isNew = false;
-        _ = dlg.ShowAsync();
+        open = true;
     }
 
-    Task Hide() => dlg.HideAsync();
+    void Hide() => open = false;
 
     async Task Save()
     {
@@ -56,7 +64,7 @@
             await ApiClient.CreateAsync(new CreateNumberTemplateDto { Name = model.Name, TargetType = model.TargetType, TemplateText = model.TemplateText, ResetPolicy = model.ResetPolicy });
         else
             await ApiClient.UpdateAsync(model.Id, new UpdateNumberTemplateDto { Name = model.Name, TargetType = model.TargetType, TemplateText = model.TemplateText, ResetPolicy = model.ResetPolicy });
-        await dlg.HideAsync();
+        open = false;
         if (OnSaved.HasDelegate) await OnSaved.InvokeAsync();
     }
 

--- a/Client.Wasm/Client.Wasm/Pages/NumberTemplates.razor
+++ b/Client.Wasm/Client.Wasm/Pages/NumberTemplates.razor
@@ -4,26 +4,30 @@
 @inject INumberTemplateApiClient ApiClient
 
 <div class="p-4">
-    <SfCard CssClass="mb-4">
-        <CardHeader>
-            <h1 class="text-xl font-semibold mb-2">Шаблоны номеров</h1>
-        </CardHeader>
-        <CardContent>
-            <SfButton CssClass="e-primary mb-3" IconCss="e-icons e-add" OnClick="@(e => edit.Show())">Добавить</SfButton>
-            <SfGrid DataSource="@items" TItem="NumberTemplateDto" AllowPaging="true" Width="100%">
-                <GridColumns>
-                    <GridColumn Field=@nameof(NumberTemplateDto.Name) HeaderText="Название" Width="200" />
-                    <GridColumn Field=@nameof(NumberTemplateDto.TargetType) HeaderText="Тип" Width="150" />
-                    <GridColumn Field=@nameof(NumberTemplateDto.TemplateText) HeaderText="Шаблон" Width="200" />
-                    <GridColumn HeaderText="" Width="100" TextAlign="TextAlign.Center">
-                        <Template>
-                            <SfButton CssClass="e-flat" IconCss="e-icons e-edit" OnClick="@( (MouseEventArgs args) => edit.Load((context as NumberTemplateDto).Id) )" />
-                        </Template>
-                    </GridColumn>
-                </GridColumns>
-            </SfGrid>
-        </CardContent>
-    </SfCard>
+    <MudCard Class="mb-4">
+        <MudCardHeader>
+            <MudText Typo="Typo.h6" Class="mb-2">Шаблоны номеров</MudText>
+        </MudCardHeader>
+        <MudCardContent>
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" Class="mb-3" OnClick="(() => edit.Show())">Добавить</MudButton>
+            <MudTable Items="@items" Hover="true" Dense="true">
+                <HeaderContent>
+                    <MudTh>Название</MudTh>
+                    <MudTh>Тип</MudTh>
+                    <MudTh>Шаблон</MudTh>
+                    <MudTh Class="text-center"></MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Название">@context.Name</MudTd>
+                    <MudTd DataLabel="Тип">@context.TargetType</MudTd>
+                    <MudTd DataLabel="Шаблон">@context.TemplateText</MudTd>
+                    <MudTd Class="text-center">
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit" OnClick="@( (MouseEventArgs args) => edit.Load(context.Id) )" />
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+        </MudCardContent>
+    </MudCard>
     <NumberTemplateEdit @ref="edit" OnSaved="Load" />
 </div>
 


### PR DESCRIPTION
## Summary
- replace Syncfusion components in `NumberTemplates.razor` with MudBlazor equivalents
- replace Syncfusion components in `NumberTemplateEdit.razor` with MudBlazor equivalents

## Testing
- `dotnet build GovServicesSolution.sln` *(fails: Sf components remain in other pages)*

------
https://chatgpt.com/codex/tasks/task_e_685a72caa6f4832384a4fb398a476ad4