### PR TITLE
Replace Syncfusion components in Orders pages

### DIFF
--- a/Client.Wasm/Client.Wasm/Pages/OrderEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/OrderEdit.razor
@@ -1,33 +1,27 @@
 @attribute [Authorize]
 @using Client.Wasm.DTOs
-@inject IJSRuntime Js
-@inject NavigationManager NavigationManager
 
 @if (visible)
 {
-    <SfDialog Width="450px" ShowCloseIcon="true" Header="@hdr" IsModal="true" Visible="true" CssClass="e-bootstrap5">
-        <EditForm Model="model" OnValidSubmit="Save">
-            <DataAnnotationsValidator />
-            <SfTab CssClass="e-bootstrap5">
-                <TabItems>
-                    <TabItem>
-    <ChildContent>
-        <TabHeader Text="Основное"></TabHeader>
-    </ChildContent>
-    <ContentTemplate>
-                        <SfTextBox @bind-Value="model.Number" Placeholder="Номер" CssClass="mb-3 w-100" />
-                        <SfDatePicker @bind-Value="model.Date" CssClass="mb-3 w-100" />
-                        <SfTextBox Multiline="true" @bind-Value="model.Text" Placeholder="Текст" CssClass="mb-3 w-100" Rows="3" />
-                    </ContentTemplate>
-</TabItem>
-                </TabItems>
-            </SfTab>
-            <div class="text-right mt-3">
-                <SfButton Type="Submit" CssClass="e-primary me-2">Сохранить</SfButton>
-                <SfButton CssClass="e-flat" OnClick="Hide">Отмена</SfButton>
-            </div>
-        </EditForm>
-    </SfDialog>
+    <MudDialog @bind-Visible="visible" MaxWidth="MaxWidth.Small">
+        <DialogContent>
+            <MudText Typo="Typo.h6" Class="mb-2">@hdr</MudText>
+            <EditForm Model="model" OnValidSubmit="Save">
+                <DataAnnotationsValidator />
+                <MudTabs>
+                    <MudTabPanel Text="Основное">
+                        <MudTextField @bind-Value="model.Number" Label="Номер" Class="mb-3 w-100" />
+                        <MudDatePicker @bind-Date="model.Date" Class="mb-3 w-100" />
+                        <MudTextField Lines="3" @bind-Value="model.Text" Label="Текст" Class="mb-3 w-100" />
+                    </MudTabPanel>
+                </MudTabs>
+                <div class="text-right mt-3">
+                    <MudButton Type="Submit" Color="Color.Primary" Class="me-2">Сохранить</MudButton>
+                    <MudButton Variant="Variant.Text" OnClick="Hide">Отмена</MudButton>
+                </div>
+            </EditForm>
+        </DialogContent>
+    </MudDialog>
 }
 
 @code {

--- a/Client.Wasm/Client.Wasm/Pages/Orders.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Orders.razor
@@ -2,32 +2,34 @@
 @page "/orders"
 
 @using Client.Wasm.DTOs
-@inject IJSRuntime Js
-@inject NavigationManager NavigationManager
-<div class="container p-4">
-    <SfCard CssClass="mb-4">
-        <CardHeader>
-            <h1>Приказы</h1>
-        </CardHeader>
-        <CardContent>
-            <SfButton CssClass="e-primary mb-3" OnClick="(() => edit.Show(new OrderDto()))">Добавить приказ</SfButton>
-            <SfGrid DataSource="@orders" AllowPaging="true" CssClass="e-bootstrap5">
-            <GridPageSettings PageSize="10" />
-            <GridColumns>
-                <GridColumn Field=@nameof(OrderDto.Id) HeaderText="ID" Width="70" TextAlign="TextAlign.Center" />
-            <GridColumn Field=@nameof(OrderDto.Number) HeaderText="Номер" Width="120" />
-            <GridColumn Field=@nameof(OrderDto.Date) HeaderText="Дата" Format="d" Width="120" />
-            <GridColumn HeaderText="" Width="120" TextAlign="TextAlign.Center">
-                <Template>
-                    <SfButton CssClass="e-flat" IconCss="e-icons e-edit" OnClick="@( (MouseEventArgs e) => edit.Load((context as OrderDto).Id) )"></SfButton>
-                </Template>
-            </GridColumn>
-            </GridColumns>
-        </SfGrid>
-        </CardContent>
-    </SfCard>
+
+<MudContainer MaxWidth="MaxWidth.False" Class="p-4">
+    <MudCard Class="mb-4">
+        <MudCardHeader>
+            <MudText Typo="Typo.h5">Приказы</MudText>
+        </MudCardHeader>
+        <MudCardContent>
+            <MudButton Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" Class="mb-3" OnClick="(() => edit.Show(new OrderDto()))">Добавить приказ</MudButton>
+            <MudTable Items="@orders" Hover="true" Dense="true">
+                <HeaderContent>
+                    <MudTh>ID</MudTh>
+                    <MudTh>Номер</MudTh>
+                    <MudTh>Дата</MudTh>
+                    <MudTh Class="text-center"></MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="ID">@context.Id</MudTd>
+                    <MudTd DataLabel="Номер">@context.Number</MudTd>
+                    <MudTd DataLabel="Дата">@context.Date.ToShortDateString()</MudTd>
+                    <MudTd Class="text-center" DataLabel="">
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit" OnClick="@(() => edit.Load(context.Id))" />
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+        </MudCardContent>
+    </MudCard>
     <OrderEdit @ref="edit" OnSaved="Reload" />
-</div>
+</MudContainer>
 
 @code {
     List<OrderDto> orders = new();


### PR DESCRIPTION
## Summary
- swap Syncfusion components for MudBlazor on `Orders.razor` and `OrderEdit.razor`
- update markup for MudBlazor dialogs and tables

## Testing
- `dotnet build GovServicesSolution.sln` *(fails: Sf* components remain in other pages)*

------
https://chatgpt.com/codex/tasks/task_e_685a77545b0083238f53188e9beb7a31