### PR TITLE
Remove incorrect MudThemeProvider usage

### DIFF
--- a/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
+++ b/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
@@ -1,8 +1,7 @@
 @inherits LayoutComponentBase
 @inject NavigationManager Nav
 
-<MudThemeProvider Theme="_theme">
-    <MudLayout>
+<MudLayout>
         <MudAppBar Color="Color.Primary">
             <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="ToggleDrawer" />
             <MudText Typo="Typo.h6" Class="ml-2">Госуслуги</MudText>
@@ -34,14 +33,9 @@
                 @Body
             </MudContainer>
         </MudMainContent>
-    </MudLayout>
-</MudThemeProvider>
+</MudLayout>
 
 @code {
     private bool _drawerOpen;
-
-    // TODO: настроить тему MudBlazor
-    private MudTheme _theme = new MudTheme();
-
     void ToggleDrawer() => _drawerOpen = !_drawerOpen;
 }


### PR DESCRIPTION
## Summary
- remove the `<MudThemeProvider>` wrapper from `MainLayout` and use `MudLayout` directly

## Testing
- `dotnet test` *(fails: Cannot provide a value for property 'Localizer' on 'MudBlazor.MudTextField`1'.)*

------
https://chatgpt.com/codex/tasks/task_e_685aa8535d5083239929bc8edae19df7