### PR TITLE
Fix missing MudPopoverProvider

### DIFF
--- a/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
+++ b/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
@@ -1,5 +1,6 @@
 @inherits LayoutComponentBase
 @inject NavigationManager Nav
+@using MudBlazor
 
 <MudLayout>
         <MudAppBar Color="Color.Primary">
@@ -27,6 +28,7 @@
                 <MudNavLink Href="ai">🧠 ИИ</MudNavLink>
             </MudNavMenu>
         </MudDrawer>
+        <MudPopoverProvider />
 
         <MudMainContent>
             <MudContainer Class="mt-4 px-4">


### PR DESCRIPTION
## Summary
- add `@using MudBlazor` to layout
- register `MudPopoverProvider` inside `MudLayout`
- verified dotnet 8 installation

## Testing
- `dotnet test` *(fails: Cannot provide a value for property 'Localizer' on type 'MudBlazor.MudTextField'*

------
https://chatgpt.com/codex/tasks/task_e_685aabb9d770832393f44d39e371c743