### PR TITLE
Add MudPopoverProvider to layout

### DIFF
--- a/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
+++ b/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
@@ -1,7 +1,8 @@
 @inherits LayoutComponentBase
 @inject NavigationManager Nav
 
-<MudLayout>
+<MudThemeProvider>
+    <MudLayout>
         <MudAppBar Color="Color.Primary">
             <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="ToggleDrawer" />
             <MudText Typo="Typo.h6" Class="ml-2">Госуслуги</MudText>
@@ -28,12 +29,16 @@
             </MudNavMenu>
         </MudDrawer>
 
+        <MudPopoverProvider />
+
         <MudMainContent>
             <MudContainer Class="mt-4 px-4">
                 @Body
             </MudContainer>
         </MudMainContent>
-</MudLayout>
+
+    </MudLayout>
+</MudThemeProvider>
 
 @code {
     private bool _drawerOpen;


### PR DESCRIPTION
## Summary
- wrap the main layout in `MudThemeProvider`
- add `MudPopoverProvider` inside `MudLayout`

## Testing
- `dotnet test` *(fails: System.InvalidOperationException: Cannot provide a value for property 'Localizer' on type 'MudBlazor.MudTextField`1`)*

------
https://chatgpt.com/codex/tasks/task_e_685ab42724f0832383b7d690229adb8b