### PR TITLE
Fix MudBlazor theme provider usage

### DIFF
--- a/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
+++ b/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
@@ -1,7 +1,9 @@
 @inherits LayoutComponentBase
 @inject NavigationManager Nav
 
-<MudThemeProvider>
+<MudThemeProvider Theme="@_theme" />
+
+<MudThemeProviderWrapper>
     <MudLayout>
         <MudAppBar Color="Color.Primary">
             <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="ToggleDrawer" />
@@ -38,9 +40,11 @@
         </MudMainContent>
 
     </MudLayout>
-</MudThemeProvider>
+</MudThemeProviderWrapper>
 
 @code {
     private bool _drawerOpen;
+    private MudTheme _theme = new MudTheme();
+
     void ToggleDrawer() => _drawerOpen = !_drawerOpen;
 }


### PR DESCRIPTION
## Summary
- update `MainLayout` to use `MudThemeProviderWrapper`
- define a default `MudTheme`
- ensure `MudPopoverProvider` stays inside the layout
- install .NET 8 for build/test

## Testing
- `dotnet build GovServicesSolution.sln`
- `dotnet test GovServicesSolution.sln` *(fails: LoginPageTests.Login_ShowsError_WhenPasswordMissing, LoginPageTests.Login_NavigatesHome_WhenSuccess)*

------
https://chatgpt.com/codex/tasks/task_e_685ab5d884b08323a24367d272c9b255