### PR TITLE
Ensure MudBlazor JS and providers

### DIFF
--- a/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
+++ b/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
@@ -1,9 +1,7 @@
 @inherits LayoutComponentBase
 @inject NavigationManager Nav
 
-<MudThemeProvider Theme="@_theme" />
-
-<MudThemeProviderWrapper>
+<MudThemeProviderWrapper Theme="@_theme">
     <MudLayout>
         <MudAppBar Color="Color.Primary">
             <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="ToggleDrawer" />
@@ -32,6 +30,8 @@
         </MudDrawer>
 
         <MudPopoverProvider />
+        <MudSnackbarProvider />
+        <MudDialogProvider />
 
         <MudMainContent>
             <MudContainer Class="mt-4 px-4">

--- a/Client.Wasm/Client.Wasm/wwwroot/index.html
+++ b/Client.Wasm/Client.Wasm/wwwroot/index.html
@@ -40,6 +40,7 @@
         <a class="dismiss">🗙</a>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-62fa5cad87f4b58de51c1eb434d9265dce6cf5f0d564b112680039e4d0f33b1872f4691c21db252b578decdea321e1f3" crossorigin="anonymous"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- load MudBlazor JavaScript in Blazor WASM `index.html`
- wrap layout in `MudThemeProviderWrapper` and add snackbar & dialog providers

## Testing
- `dotnet test` *(fails: 2 tests)*

------
https://chatgpt.com/codex/tasks/task_e_685ab7fdd3688323b32b260a23f3a497