### PR TITLE
Fix missing service namespace

### DIFF
--- a/Client.Wasm/Client.Wasm/_Imports.razor
+++ b/Client.Wasm/Client.Wasm/_Imports.razor
@@ -11,6 +11,7 @@
 @using Client.Wasm
 @using Client.Wasm.Layout
 @using Services = Client.Wasm.Services
+@using Client.Wasm.Services
 @using Client.Wasm.DTOs
 @using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Components.Web


### PR DESCRIPTION
## Summary
- ensure service namespace is imported for Razor pages

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: LoginPageTests)*

------
https://chatgpt.com/codex/tasks/task_e_685abd3952ec832398bd9848769b40c4