### PR TITLE
Fix startup error by removing MudBlazor services

### DIFF
--- a/Server.Api/Server.Api/Program.cs
+++ b/Server.Api/Server.Api/Program.cs
@@ -102,7 +102,6 @@ builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
 
 // Controllers
 builder.Services.AddControllers();
-builder.Services.AddMudServices();
 
 // Swagger/OpenAPI
 builder.Services.AddEndpointsApiExplorer();


### PR DESCRIPTION
## Summary
- remove `AddMudServices` call from API setup to avoid missing dependencies

## Testing
- `dotnet build Server.Api/Server.Api/Server.Api.csproj -clp:ErrorsOnly`
- `dotnet test Server.Tests/Server.Tests.csproj`
- `dotnet test Client.Wasm.Tests/Client.Wasm.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_685bd08683f48323b282a4986b165619