### PR TITLE
Fix login API base URL

### DIFF
--- a/Client.Wasm/Client.Wasm/Program.cs
+++ b/Client.Wasm/Client.Wasm/Program.cs
@@ -15,7 +15,8 @@ builder.Services.AddScoped<ErrorHandlerService>();
 builder.Services.AddScoped(sp =>
 {
     var handler = new ErrorHandlingMessageHandler(sp.GetRequiredService<ErrorHandlerService>());
-    return new HttpClient(handler) { BaseAddress = new Uri("http://localhost:5141/") };
+    var apiBase = builder.Configuration["API_BASE_URL"] ?? "http://localhost:5141/";
+    return new HttpClient(handler) { BaseAddress = new Uri(apiBase) };
 });
 
 // Регистрация клиентских сервисов

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       dockerfile: Client.Wasm/Dockerfile
     depends_on:
       - server
+    environment:
+      - API_BASE_URL=http://server
     ports:
       - "5002:80"
 


### PR DESCRIPTION
## Summary
- allow API base URL to be configured via `API_BASE_URL`
- pass `API_BASE_URL` to client container in compose file

## Testing
- `dotnet test GovServicesSolution.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685bd4a9eb8c8323bc706d0f8a3289a1