### PR TITLE
Fix await usage in MainLayout

### DIFF
--- a/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
+++ b/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
@@ -5,10 +5,7 @@
 @inject IAuthService AuthService
 
 <CascadingAuthenticationState>
-    @{
-        var authState = await AuthProvider.GetAuthenticationStateAsync();
-    }
-    @if (authState.User.Identity?.IsAuthenticated == true)
+    @if (_authState?.User.Identity?.IsAuthenticated == true)
     {
         <MudThemeProvider>
             <MudDialogProvider>
@@ -61,6 +58,13 @@
 </CascadingAuthenticationState>
 
 @code {
+    private AuthenticationState? _authState;
+
+    protected override async Task OnInitializedAsync()
+    {
+        _authState = await AuthProvider.GetAuthenticationStateAsync();
+    }
+
     private void GoToProfile() => Nav.NavigateTo("/profile");
 
     private async Task Logout()


### PR DESCRIPTION
## Summary
- retrieve authentication state inside `OnInitializedAsync`
- use field `_authState` for layout authentication check

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685bdf8552188323b5e6e73847d17f83