### PR TITLE
Fix MudThemeProvider layout usage

### DIFF
--- a/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
+++ b/Client.Wasm/Client.Wasm/Layout/MainLayout.razor
@@ -7,11 +7,11 @@
 <CascadingAuthenticationState>
     @if (_authState?.User.Identity?.IsAuthenticated == true)
     {
-        <MudThemeProvider>
-            <MudDialogProvider>
-                <MudPopoverProvider>
-                    <MudSnackbarProvider>
-                        <MudAppBar Elevation="1">
+        <MudThemeProvider />
+        <MudDialogProvider />
+        <MudPopoverProvider />
+        <MudSnackbarProvider />
+        <MudAppBar Elevation="1">
                             <MudText Typo="Typo.h6">Госуслуги</MudText>
                             <MudSpacer />
                             <MudMenu Label="📑 Документы" StartIcon="@Icons.Material.Filled.Folder">
@@ -46,10 +46,6 @@
                         <MudFooter Class="mt-4 px-4 text-center">
                             © 2025 Госуслуги
                         </MudFooter>
-                    </MudSnackbarProvider>
-                </MudPopoverProvider>
-            </MudDialogProvider>
-        </MudThemeProvider>
     }
     else
     {


### PR DESCRIPTION
## Summary
- correct usage of `MudThemeProvider` and provider components so they match MudBlazor 8.x API
- self-close provider tags and remove obsolete wrapping

## Testing
- `dotnet build GovServicesSolution.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685be9779d4c8323a234db2e95e6be2e