### PR TITLE
Fix menu alignment and sticky footer

### DIFF
--- a/Client.Wasm/Client.Wasm/Components/TopNav.razor
+++ b/Client.Wasm/Client.Wasm/Components/TopNav.razor
@@ -50,8 +50,7 @@
                     <MudMenuItem Href="/ai">Модель ИИ</MudMenuItem>
                     <MudMenuItem Href="/ai/settings">Настройки ИИ</MudMenuItem>
                 </MudMenu>
-                <MudSpacer />
-                <MudMenu Icon="@Icons.Material.Filled.AccountCircle">
+                <MudMenu Icon="@Icons.Material.Filled.AccountCircle" Class="ms-auto">
                     <MudMenuItem OnClick="Profile">Настройки профиля</MudMenuItem>
                     <MudMenuItem OnClick="Logout">Выход</MudMenuItem>
                 </MudMenu>

--- a/Client.Wasm/Client.Wasm/wwwroot/css/site.css
+++ b/Client.Wasm/Client.Wasm/wwwroot/css/site.css
@@ -12,6 +12,22 @@ html, body {
     color: #1f2937;
 }
 
+body {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+#app {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.mud-main-content {
+    flex: 1 0 auto;
+}
+
 .login-background {
     min-height: 100vh;
     background: linear-gradient(to bottom right, #dbeafe, #eff6ff);


### PR DESCRIPTION
## Summary
- align account menu to the right edge in the top navigation
- ensure footer stays at the bottom with flex layout

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685c0366752483239566a2d79583d8cd