### PR TITLE
Improve responsive TopNav layout

### DIFF
--- a/Client.Wasm/Client.Wasm/Components/TopNav.razor
+++ b/Client.Wasm/Client.Wasm/Components/TopNav.razor
@@ -4,53 +4,83 @@
 <AuthorizeView>
     <Authorized>
         <MudAppBar Color="Color.Primary">
-            <MudToolbar Class="justify-center">
+            <MudToolbar>
                 <a href="/" class="d-flex align-items-center text-decoration-none me-4">
                     <span class="h3 mb-0 me-2">🏛️</span>
                     <span class="fw-semibold h5 mb-0">Государственные услуги</span>
                 </a>
-                <MudMenu Label="Заявления" StartIcon="@Icons.Material.Filled.Description">
+
+                <div class="center-menu d-none d-md-flex">
+                    <MudMenu Label="Заявления" StartIcon="@Icons.Material.Filled.Description">
+                        <MudMenuItem Href="/applications">Все заявления</MudMenuItem>
+                        <MudMenuItem Href="/registry/applications">Реестр заявлений</MudMenuItem>
+                        <MudMenuItem Href="/registry/rdz-orders">РДЗ</MudMenuItem>
+                        <MudMenuItem Href="/registry/rdi-orders">РДИ</MudMenuItem>
+                    </MudMenu>
+                    <MudMenu Label="Документы" StartIcon="@Icons.Material.Filled.Folder">
+                        <MudMenuItem Href="/registry/contracts">Договоры</MudMenuItem>
+                        <MudMenuItem Href="/registry/acts">Акты</MudMenuItem>
+                        <MudMenuItem Href="/registry/agreements">Соглашения</MudMenuItem>
+                        <MudMenuItem Href="/registry/rdz-orders">Распоряжения земли</MudMenuItem>
+                        <MudMenuItem Href="/registry/rdi-orders">Распоряжения имущества</MudMenuItem>
+                    </MudMenu>
+                    <MudMenu Label="Справочники" StartIcon="@Icons.Material.Filled.MenuBook">
+                        <MudMenuItem Href="/dictionaries">Справочники</MudMenuItem>
+                        <MudMenuItem Href="/templates">Шаблоны</MudMenuItem>
+                        <MudMenuItem Href="/service-templates">Шаблоны услуг</MudMenuItem>
+                    </MudMenu>
+                    <MudMenu Label="Структура" StartIcon="@Icons.Material.Filled.Apartment">
+                        <MudMenuItem Href="/departments">Подразделения</MudMenuItem>
+                        <MudMenuItem Href="/positions">Должности</MudMenuItem>
+                    </MudMenu>
+                    <MudMenu Label="Гео" StartIcon="@Icons.Material.Filled.Map">
+                        <MudMenuItem Href="/geoobjects">Геообъекты</MudMenuItem>
+                    </MudMenu>
+                    <MudMenu Label="Пользователи и роли" StartIcon="@Icons.Material.Filled.People">
+                        <MudMenuItem Href="/users">Список пользователей</MudMenuItem>
+                        <MudMenuItem Href="/roles">Роли и доступ</MudMenuItem>
+                    </MudMenu>
+                    <MudMenu Label="Настройки" StartIcon="@Icons.Material.Filled.Settings">
+                        <MudMenuItem Href="/settings">Общие</MudMenuItem>
+                        <MudMenuItem Href="/settings/integrations">Интеграции</MudMenuItem>
+                    </MudMenu>
+                    <MudMenu Label="Отчёты" StartIcon="@Icons.Material.Filled.BarChart">
+                        <MudMenuItem Href="/reports/stats">Статистика</MudMenuItem>
+                        <MudMenuItem Href="/reports/export">Выгрузки</MudMenuItem>
+                    </MudMenu>
+                    <MudMenu Label="ИИ" StartIcon="@Icons.Material.Filled.SmartToy">
+                        <MudMenuItem Href="/ai">Модель ИИ</MudMenuItem>
+                        <MudMenuItem Href="/ai/settings">Настройки ИИ</MudMenuItem>
+                    </MudMenu>
+                </div>
+
+                <MudMenu Icon="@Icons.Material.Filled.Menu" Class="d-md-none">
                     <MudMenuItem Href="/applications">Все заявления</MudMenuItem>
                     <MudMenuItem Href="/registry/applications">Реестр заявлений</MudMenuItem>
                     <MudMenuItem Href="/registry/rdz-orders">РДЗ</MudMenuItem>
                     <MudMenuItem Href="/registry/rdi-orders">РДИ</MudMenuItem>
-                </MudMenu>
-                <MudMenu Label="Документы" StartIcon="@Icons.Material.Filled.Folder">
                     <MudMenuItem Href="/registry/contracts">Договоры</MudMenuItem>
                     <MudMenuItem Href="/registry/acts">Акты</MudMenuItem>
                     <MudMenuItem Href="/registry/agreements">Соглашения</MudMenuItem>
                     <MudMenuItem Href="/registry/rdz-orders">Распоряжения земли</MudMenuItem>
                     <MudMenuItem Href="/registry/rdi-orders">Распоряжения имущества</MudMenuItem>
-                </MudMenu>
-                <MudMenu Label="Справочники" StartIcon="@Icons.Material.Filled.MenuBook">
                     <MudMenuItem Href="/dictionaries">Справочники</MudMenuItem>
                     <MudMenuItem Href="/templates">Шаблоны</MudMenuItem>
                     <MudMenuItem Href="/service-templates">Шаблоны услуг</MudMenuItem>
-                </MudMenu>
-                <MudMenu Label="Структура" StartIcon="@Icons.Material.Filled.Apartment">
                     <MudMenuItem Href="/departments">Подразделения</MudMenuItem>
                     <MudMenuItem Href="/positions">Должности</MudMenuItem>
-                </MudMenu>
-                <MudMenu Label="Гео" StartIcon="@Icons.Material.Filled.Map">
                     <MudMenuItem Href="/geoobjects">Геообъекты</MudMenuItem>
-                </MudMenu>
-                <MudMenu Label="Пользователи и роли" StartIcon="@Icons.Material.Filled.People">
                     <MudMenuItem Href="/users">Список пользователей</MudMenuItem>
                     <MudMenuItem Href="/roles">Роли и доступ</MudMenuItem>
-                </MudMenu>
-                <MudMenu Label="Настройки" StartIcon="@Icons.Material.Filled.Settings">
-                    <MudMenuItem Href="/settings">Общие</MudMenuItem>
+                    <MudMenuItem Href="/settings">Общие настройки</MudMenuItem>
                     <MudMenuItem Href="/settings/integrations">Интеграции</MudMenuItem>
-                </MudMenu>
-                <MudMenu Label="Отчёты" StartIcon="@Icons.Material.Filled.BarChart">
                     <MudMenuItem Href="/reports/stats">Статистика</MudMenuItem>
                     <MudMenuItem Href="/reports/export">Выгрузки</MudMenuItem>
-                </MudMenu>
-                <MudMenu Label="ИИ" StartIcon="@Icons.Material.Filled.SmartToy">
                     <MudMenuItem Href="/ai">Модель ИИ</MudMenuItem>
                     <MudMenuItem Href="/ai/settings">Настройки ИИ</MudMenuItem>
                 </MudMenu>
-                <MudMenu Icon="@Icons.Material.Filled.AccountCircle">
+
+                <MudMenu Icon="@Icons.Material.Filled.AccountCircle" Class="ms-auto">
                     <MudMenuItem OnClick="Profile">Настройки профиля</MudMenuItem>
                     <MudMenuItem OnClick="Logout">Выход</MudMenuItem>
                 </MudMenu>

--- a/Client.Wasm/Client.Wasm/Components/TopNav.razor.css
+++ b/Client.Wasm/Client.Wasm/Components/TopNav.razor.css
@@ -23,3 +23,9 @@
         margin-left: 0;
     }
 }
+
+.center-menu {
+    flex-grow: 1;
+    display: flex;
+    justify-content: center;
+}


### PR DESCRIPTION
## Summary
- adjust TopNav markup for a centered responsive menu
- add menu icon for mobile layout
- align profile menu on the right
- add CSS to center the menu area

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685c06f75cf4832396f8dd0f7c5556e6