### PR TITLE
Add page access management

### DIFF
--- a/Client.Wasm/Client.Wasm/DTOs/CreatePageAccessDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/CreatePageAccessDto.cs
@@ -1,0 +1,7 @@
+namespace Client.Wasm.DTOs;
+
+public class CreatePageAccessDto
+{
+    public string UserId { get; set; } = string.Empty;
+    public string PageUrl { get; set; } = string.Empty;
+}

--- a/Client.Wasm/Client.Wasm/DTOs/PageAccessDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/PageAccessDto.cs
@@ -1,0 +1,8 @@
+namespace Client.Wasm.DTOs;
+
+public class PageAccessDto
+{
+    public int Id { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public string PageUrl { get; set; } = string.Empty;
+}

--- a/Client.Wasm/Client.Wasm/Pages/PageAccess.razor
+++ b/Client.Wasm/Client.Wasm/Pages/PageAccess.razor
@@ -1,0 +1,57 @@
+@page "/page-access"
+@attribute [Authorize(Roles="Администратор")]
+@inject IPageAccessApiClient Api
+@inject IUserApiClient UserApi
+@using Client.Wasm.DTOs
+
+<h3>Доступ к страницам</h3>
+
+<MudPaper Class="p-4">
+    <MudSelect T="string" Label="Пользователь" @bind-Value="selectedUserId">
+        @foreach (var user in users)
+        {
+            <MudSelectItem Value="@user.Id">@user.FullName (@user.Email)</MudSelectItem>
+        }
+    </MudSelect>
+
+    <MudTextField Label="URL страницы" @bind-Value="newPageUrl" Class="mt-4" />
+    <MudButton OnClick="AddAccess" Disabled="@(string.IsNullOrWhiteSpace(selectedUserId) || string.IsNullOrWhiteSpace(newPageUrl))" Class="mt-2">Добавить</MudButton>
+
+    <MudTable Items="accesses.Where(a => a.UserId == selectedUserId)" Dense="true" Class="mt-4">
+        <HeaderContent>
+            <MudTh>Страница</MudTh>
+            <MudTh></MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Страница">@context.PageUrl</MudTd>
+            <MudTd><MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="() => RemoveAccess(context.Id)" /></MudTd>
+        </RowTemplate>
+    </MudTable>
+</MudPaper>
+
+@code {
+    private List<UserDto> users = new();
+    private List<PageAccessDto> accesses = new();
+    private string selectedUserId = string.Empty;
+    private string newPageUrl = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        users = await UserApi.GetAllAsync();
+        accesses = await Api.GetAllAsync();
+    }
+
+    private async Task AddAccess()
+    {
+        var dto = new CreatePageAccessDto { UserId = selectedUserId, PageUrl = newPageUrl };
+        var created = await Api.CreateAsync(dto);
+        accesses.Add(created);
+        newPageUrl = string.Empty;
+    }
+
+    private async Task RemoveAccess(int id)
+    {
+        await Api.DeleteAsync(id);
+        accesses.RemoveAll(a => a.Id == id);
+    }
+}

--- a/Client.Wasm/Client.Wasm/Services/MenuService.cs
+++ b/Client.Wasm/Client.Wasm/Services/MenuService.cs
@@ -50,6 +50,7 @@ public class MenuService
         var groupRights = new MenuGroup { Title = "🔐 Права" };
         AddIfExists(pages, groupRights.Items, "/permissions", "Права доступа");
         AddIfExists(pages, groupRights.Items, "/permission-groups", "Группы прав");
+        AddIfExists(pages, groupRights.Items, "/page-access", "Доступ к страницам");
         if (groupRights.Items.Count > 0) Groups.Add(groupRights);
 
         var groupSettings = new MenuGroup { Title = "⚙️ Настройки" };

--- a/Client.Wasm/Client.Wasm/Services/PageAccessApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/PageAccessApiClient.cs
@@ -1,0 +1,41 @@
+namespace Client.Wasm.Services;
+
+using System.Net.Http.Json;
+using Client.Wasm.DTOs;
+using Client.Wasm.Helpers;
+
+public interface IPageAccessApiClient
+{
+    Task<List<PageAccessDto>> GetAllAsync();
+    Task<PageAccessDto> CreateAsync(CreatePageAccessDto dto);
+    Task DeleteAsync(int id);
+}
+
+public class PageAccessApiClient : IPageAccessApiClient
+{
+    private readonly HttpClient _http;
+
+    public PageAccessApiClient(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<List<PageAccessDto>> GetAllAsync()
+    {
+        var result = await _http.GetFromJsonSafeAsync<List<PageAccessDto>>("api/pageaccesses");
+        return result ?? new();
+    }
+
+    public async Task<PageAccessDto> CreateAsync(CreatePageAccessDto dto)
+    {
+        var res = await _http.PostAsJsonAsync("api/pageaccesses", dto);
+        res.EnsureSuccessStatusCode();
+        return (await res.Content.ReadFromJsonAsync<PageAccessDto>())!;
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        var res = await _http.DeleteAsync($"api/pageaccesses/{id}");
+        res.EnsureSuccessStatusCode();
+    }
+}

--- a/Server.Api/Server.Api/Controllers/PageAccessesController.cs
+++ b/Server.Api/Server.Api/Controllers/PageAccessesController.cs
@@ -1,0 +1,38 @@
+using GovServices.Server.DTOs;
+using GovServices.Server.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class PageAccessesController : ControllerBase
+{
+    private readonly IPageAccessService _service;
+
+    public PageAccessesController(IPageAccessService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<PageAccessDto>>> Get()
+    {
+        var items = await _service.GetAllAsync();
+        return Ok(items);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<PageAccessDto>> Post(CreatePageAccessDto dto)
+    {
+        var item = await _service.CreateAsync(dto);
+        return CreatedAtAction(nameof(Get), new { id = item.Id }, item);
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        await _service.DeleteAsync(id);
+        return NoContent();
+    }
+}

--- a/Server.Api/Server.Api/DTOs/CreatePageAccessDto.cs
+++ b/Server.Api/Server.Api/DTOs/CreatePageAccessDto.cs
@@ -1,0 +1,7 @@
+namespace GovServices.Server.DTOs;
+
+public class CreatePageAccessDto
+{
+    public string UserId { get; set; } = string.Empty;
+    public string PageUrl { get; set; } = string.Empty;
+}

--- a/Server.Api/Server.Api/DTOs/PageAccessDto.cs
+++ b/Server.Api/Server.Api/DTOs/PageAccessDto.cs
@@ -1,0 +1,8 @@
+namespace GovServices.Server.DTOs;
+
+public class PageAccessDto
+{
+    public int Id { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public string PageUrl { get; set; } = string.Empty;
+}

--- a/Server.Api/Server.Api/Data/ApplicationDbContext.cs
+++ b/Server.Api/Server.Api/Data/ApplicationDbContext.cs
@@ -39,6 +39,7 @@ namespace GovServices.Server.Data
         public DbSet<PermissionGroup> PermissionGroups { get; set; }
         public DbSet<PermissionGroupPermission> PermissionGroupPermissions { get; set; }
         public DbSet<UserPermissionGroup> UserPermissionGroups { get; set; }
+        public DbSet<PageAccess> PageAccesses { get; set; }
         public DbSet<Position> Positions { get; set; }
         public DbSet<UserProfile> UserProfiles { get; set; }
         public DbSet<Dictionary> Dictionaries { get; set; }
@@ -74,6 +75,11 @@ namespace GovServices.Server.Data
                 .HasOne(pgp => pgp.Permission)
                 .WithMany(p => p.PermissionGroupPermissions)
                 .HasForeignKey(pgp => pgp.PermissionId);
+
+            builder.Entity<PageAccess>()
+                .HasOne(pa => pa.User)
+                .WithMany(u => u.PageAccesses)
+                .HasForeignKey(pa => pa.UserId);
 
             builder.Entity<Document>()
                 .HasIndex(d => new { d.OwnerId, d.Type, d.CreatedAt });

--- a/Server.Api/Server.Api/Entities/ApplicationUser.cs
+++ b/Server.Api/Server.Api/Entities/ApplicationUser.cs
@@ -9,5 +9,6 @@ namespace GovServices.Server.Entities
         public DateTime PasswordLastChangedAt { get; set; }
         public ICollection<Application> AssignedApplications { get; set; }
         public ICollection<UserPermissionGroup> PermissionGroups { get; set; }
+        public ICollection<PageAccess> PageAccesses { get; set; } = new List<PageAccess>();
     }
 }

--- a/Server.Api/Server.Api/Entities/PageAccess.cs
+++ b/Server.Api/Server.Api/Entities/PageAccess.cs
@@ -1,0 +1,9 @@
+namespace GovServices.Server.Entities;
+
+public class PageAccess
+{
+    public int Id { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public ApplicationUser User { get; set; } = default!;
+    public string PageUrl { get; set; } = string.Empty;
+}

--- a/Server.Api/Server.Api/Interfaces/IPageAccessService.cs
+++ b/Server.Api/Server.Api/Interfaces/IPageAccessService.cs
@@ -1,0 +1,10 @@
+using GovServices.Server.DTOs;
+
+namespace GovServices.Server.Interfaces;
+
+public interface IPageAccessService
+{
+    Task<List<PageAccessDto>> GetAllAsync();
+    Task<PageAccessDto> CreateAsync(CreatePageAccessDto dto);
+    Task DeleteAsync(int id);
+}

--- a/Server.Api/Server.Api/Mappings/MappingProfile.cs
+++ b/Server.Api/Server.Api/Mappings/MappingProfile.cs
@@ -126,6 +126,8 @@ namespace GovServices.Server.Mappings
             CreateMap<Permission, PermissionDto>().ReverseMap();
             CreateMap<CreatePermissionDto, Permission>();
             CreateMap<UpdatePermissionDto, Permission>();
+            CreateMap<PageAccess, PageAccessDto>().ReverseMap();
+            CreateMap<CreatePageAccessDto, PageAccess>();
         }
 
         private static List<ExecutionStage>? DeserializeStages(string? json)

--- a/Server.Api/Server.Api/Migrations/20250626072308_AddPageAccess.Designer.cs
+++ b/Server.Api/Server.Api/Migrations/20250626072308_AddPageAccess.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using GovServices.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Server.Api.Migrations
+namespace Server.Api.Server.Api.Server.Api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250626072308_AddPageAccess")]
+    partial class AddPageAccess
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server.Api/Server.Api/Migrations/20250626072308_AddPageAccess.cs
+++ b/Server.Api/Server.Api/Migrations/20250626072308_AddPageAccess.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Server.Api.Server.Api.Server.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPageAccess : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PageAccesses",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<string>(type: "text", nullable: false),
+                    PageUrl = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PageAccesses", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PageAccesses_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PageAccesses_UserId",
+                table: "PageAccesses",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PageAccesses");
+        }
+    }
+}

--- a/Server.Api/Server.Api/Program.cs
+++ b/Server.Api/Server.Api/Program.cs
@@ -135,6 +135,7 @@ builder.Services.AddScoped<IDepartmentService, DepartmentService>();
 builder.Services.AddScoped<IPositionService, PositionService>();
 builder.Services.AddScoped<IUserProfileService, UserProfileService>();
 builder.Services.AddScoped<IPermissionService, PermissionService>();
+builder.Services.AddScoped<IPageAccessService, PageAccessService>();
 
 // Регистрация IEmailService (и реализация EmailService)
 builder.Services.AddScoped<IEmailService, EmailService>();

--- a/Server.Api/Server.Api/Services/PageAccessService.cs
+++ b/Server.Api/Server.Api/Services/PageAccessService.cs
@@ -1,0 +1,44 @@
+using AutoMapper;
+using GovServices.Server.Data;
+using GovServices.Server.DTOs;
+using GovServices.Server.Entities;
+using GovServices.Server.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovServices.Server.Services;
+
+public class PageAccessService : IPageAccessService
+{
+    private readonly ApplicationDbContext _context;
+    private readonly IMapper _mapper;
+
+    public PageAccessService(ApplicationDbContext context, IMapper mapper)
+    {
+        _context = context;
+        _mapper = mapper;
+    }
+
+    public async Task<List<PageAccessDto>> GetAllAsync()
+    {
+        var items = await _context.PageAccesses.ToListAsync();
+        return _mapper.Map<List<PageAccessDto>>(items);
+    }
+
+    public async Task<PageAccessDto> CreateAsync(CreatePageAccessDto dto)
+    {
+        var entity = _mapper.Map<PageAccess>(dto);
+        _context.PageAccesses.Add(entity);
+        await _context.SaveChangesAsync();
+        return _mapper.Map<PageAccessDto>(entity);
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        var entity = await _context.PageAccesses.FindAsync(id);
+        if (entity != null)
+        {
+            _context.PageAccesses.Remove(entity);
+            await _context.SaveChangesAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a PageAccess entity and migration
- expose API endpoints to manage page access
- provide DTOs and service for PageAccess
- implement client API client and UI page for admins
- update menu and DI registration

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685cf3fedbc8832390387c57943991a4