### PR TITLE
Improve menu grouping and admin role

### DIFF
--- a/Client.Wasm/Client.Wasm/Components/TopNav.razor
+++ b/Client.Wasm/Client.Wasm/Components/TopNav.razor
@@ -4,6 +4,7 @@
 @using Microsoft.AspNetCore.Authorization
 @using System.Reflection
 @using System.Security.Claims
+@using System.Linq
 
 <AuthorizeView>
     <Authorized>
@@ -18,24 +19,37 @@
                 </div>
 
                 <div class="center-menu d-none d-md-flex">
-                    @foreach (var item in Menu.Groups.SelectMany(g => g.Items))
+                    @foreach (var group in Menu.Groups)
                     {
-                        if (CanView(item))
-                        {
-                            <MudNavLink Href="@item.Url" Match="NavLinkMatch.Prefix" Class="mx-2">
-                                @item.Title
-                            </MudNavLink>
-                        }
+                        var visible = group.Items.Where(CanView).ToList();
+                        if (visible.Count == 0)
+                            continue;
+
+                        <MudMenu Dense="true" Label="@group.Title" Class="mx-2">
+                            @foreach (var item in visible)
+                            {
+                                <MudMenuItem Href="@item.Url">@item.Title</MudMenuItem>
+                            }
+                        </MudMenu>
                     }
                 </div>
 
                 <div class="right-block d-flex align-items-center">
                     <MudMenu Icon="@Icons.Material.Filled.Menu" Class="d-md-none me-2">
-                        @foreach (var item in Menu.Groups.SelectMany(g => g.Items))
+                        @foreach (var group in Menu.Groups)
                         {
-                            if (CanView(item))
+                            var visible = group.Items.Where(CanView).ToList();
+                            if (visible.Count == 0)
+                                continue;
+
+                            <MudText Class="px-2 pt-1" Typo="Typo.subtitle2">@group.Title</MudText>
+                            @foreach (var item in visible)
                             {
                                 <MudMenuItem Href="@item.Url">@item.Title</MudMenuItem>
+                            }
+                            @if (group != Menu.Groups.Last())
+                            {
+                                <MudDivider />
                             }
                         }
                     </MudMenu>

--- a/Client.Wasm/Client.Wasm/Pages/DocumentTemplates.razor
+++ b/Client.Wasm/Client.Wasm/Pages/DocumentTemplates.razor
@@ -1,4 +1,4 @@
-@attribute [Authorize(Roles="Administrator")]
+@attribute [Authorize(Roles="Администратор")]
 @page "/document-templates"
 @inject IDocumentTemplateService TemplateService
 @inject IJSRuntime JsRuntime

--- a/Client.Wasm/Client.Wasm/Pages/ServiceTemplateEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/ServiceTemplateEdit.razor
@@ -1,4 +1,4 @@
-@attribute [Authorize(Roles="Administrator")]
+@attribute [Authorize(Roles="Администратор")]
 @using Client.Wasm.DTOs
 @using Client.Wasm.Helpers
 @inject IServiceTemplateApiClient ApiClient

--- a/Client.Wasm/Client.Wasm/Pages/ServiceTemplates.razor
+++ b/Client.Wasm/Client.Wasm/Pages/ServiceTemplates.razor
@@ -1,4 +1,4 @@
-@attribute [Authorize(Roles="Administrator")]
+@attribute [Authorize(Roles="Администратор")]
 @page "/service-templates"
 @inject IServiceTemplateApiClient ApiClient
 @inject IServiceApiClient ServiceApiClient

--- a/Server.Api/Server.Api/Controllers/ServiceTemplatesController.cs
+++ b/Server.Api/Server.Api/Controllers/ServiceTemplatesController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using GovServices.Server.Entities;
 using GovServices.Server.Interfaces;
 using GovServices.Server.DTOs;
+using GovServices.Server.Authorization;
 
 namespace GovServices.Server.Controllers;
 
@@ -33,7 +34,7 @@ public class ServiceTemplatesController : ControllerBase
         return res == null ? NotFound() : Ok(res);
     }
 
-    [Authorize(Roles = "Administrator")]
+    [Authorize(Roles = RoleNames.Administrator)]
     [HttpPost]
     public async Task<ActionResult<ServiceTemplateDto>> Create(CreateServiceTemplateDto dto)
     {
@@ -42,7 +43,7 @@ public class ServiceTemplatesController : ControllerBase
         return Ok(res);
     }
 
-    [Authorize(Roles = "Administrator")]
+    [Authorize(Roles = RoleNames.Administrator)]
     [HttpPut("{id}")]
     public async Task<IActionResult> Update(int id, UpdateServiceTemplateDto dto)
     {
@@ -51,7 +52,7 @@ public class ServiceTemplatesController : ControllerBase
         return NoContent();
     }
 
-    [Authorize(Roles = "Administrator")]
+    [Authorize(Roles = RoleNames.Administrator)]
     [HttpDelete("{id}")]
     public async Task<IActionResult> Delete(int id)
     {


### PR DESCRIPTION
## Summary
- group top navigation by menu categories instead of a flat list
- display grouped items in the mobile menu
- use Russian role name for admin protected pages
- reference `RoleNames.Administrator` in service template controller

## Testing
- `dotnet build GovServicesSolution.sln`
- `dotnet test GovServicesSolution.sln`


------
https://chatgpt.com/codex/tasks/task_e_685d0e1b4e008323a4e77e4185c0ec1c