### PR TITLE
Add MinIO integration for file storage

### DIFF
--- a/Server.Api/Server.Api/Controllers/FileController.cs
+++ b/Server.Api/Server.Api/Controllers/FileController.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Services;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/files")]
+public class FileController : ControllerBase
+{
+    private readonly MinioService _minio;
+    private const string Bucket = "files";
+
+    public FileController(MinioService minio)
+    {
+        _minio = minio;
+    }
+
+    [HttpPost("upload")]
+    public async Task<IActionResult> Upload(IFormFile file)
+    {
+        await _minio.CreateBucketIfNotExistsAsync(Bucket);
+        await using var stream = file.OpenReadStream();
+        await _minio.UploadAsync(stream, Bucket, file.FileName, file.ContentType);
+        return Ok();
+    }
+
+    [HttpGet("download/{fileName}")]
+    public async Task<IActionResult> Download(string fileName)
+    {
+        var stream = await _minio.DownloadAsync(Bucket, fileName);
+        return File(stream, "application/octet-stream", fileName);
+    }
+
+    [HttpDelete("{fileName}")]
+    public async Task<IActionResult> Delete(string fileName)
+    {
+        await _minio.DeleteAsync(Bucket, fileName);
+        return NoContent();
+    }
+
+    [HttpGet("list")]
+    public async Task<IActionResult> List()
+    {
+        var files = await _minio.ListFilesAsync(Bucket);
+        return Ok(files);
+    }
+
+    [HttpPut("update/{fileName}")]
+    public async Task<IActionResult> Update(string fileName, IFormFile file)
+    {
+        await using var stream = file.OpenReadStream();
+        await _minio.UploadAsync(stream, Bucket, fileName, file.ContentType);
+        return Ok();
+    }
+}

--- a/Server.Api/Server.Api/Program.cs
+++ b/Server.Api/Server.Api/Program.cs
@@ -137,6 +137,7 @@ builder.Services.AddScoped<IPositionService, PositionService>();
 builder.Services.AddScoped<IUserProfileService, UserProfileService>();
 builder.Services.AddScoped<IPermissionService, PermissionService>();
 builder.Services.AddScoped<IPageAccessService, PageAccessService>();
+builder.Services.AddSingleton<MinioService>();
 
 // Регистрация IEmailService (и реализация EmailService)
 builder.Services.AddScoped<IEmailService, EmailService>();

--- a/Server.Api/Server.Api/Server.Api.csproj
+++ b/Server.Api/Server.Api/Server.Api.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
+    <PackageReference Include="Minio" Version="6.0.5" />
     <PackageReference Include="MudBlazor" Version="8.8.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="8.0.0" />

--- a/Server.Api/Server.Api/Services/MinioService.cs
+++ b/Server.Api/Server.Api/Services/MinioService.cs
@@ -1,0 +1,96 @@
+using Minio;
+using Minio.DataModel.Args;
+using Microsoft.Extensions.Configuration;
+
+namespace GovServices.Server.Services;
+
+public class MinioService
+{
+    private readonly IMinioClient _client;
+
+    public MinioService(IConfiguration configuration)
+    {
+        var section = configuration.GetSection("Minio");
+        var endpoint = section["Endpoint"] ?? "localhost:9000";
+        var accessKey = section["AccessKey"] ?? string.Empty;
+        var secretKey = section["SecretKey"] ?? string.Empty;
+        var useSsl = section.GetValue<bool>("UseSSL");
+
+        _client = new MinioClient()
+            .WithEndpoint(endpoint)
+            .WithCredentials(accessKey, secretKey)
+            .WithSSL(useSsl)
+            .Build();
+    }
+
+    public async Task UploadAsync(Stream stream, string bucket, string name, string contentType)
+    {
+        var args = new PutObjectArgs()
+            .WithBucket(bucket)
+            .WithObject(name)
+            .WithStreamData(stream)
+            .WithObjectSize(stream.Length)
+            .WithContentType(contentType);
+        await _client.PutObjectAsync(args);
+    }
+
+    public async Task<Stream> DownloadAsync(string bucket, string name)
+    {
+        var memory = new MemoryStream();
+        var args = new GetObjectArgs()
+            .WithBucket(bucket)
+            .WithObject(name)
+            .WithCallbackStream(s => s.CopyTo(memory));
+        await _client.GetObjectAsync(args);
+        memory.Position = 0;
+        return memory;
+    }
+
+    public Task DeleteAsync(string bucket, string name)
+    {
+        var args = new RemoveObjectArgs()
+            .WithBucket(bucket)
+            .WithObject(name);
+        return _client.RemoveObjectAsync(args);
+    }
+
+    public async Task<bool> ExistsAsync(string bucket, string name)
+    {
+        try
+        {
+            var args = new StatObjectArgs()
+                .WithBucket(bucket)
+                .WithObject(name);
+            await _client.StatObjectAsync(args);
+            return true;
+        }
+        catch (Minio.Exceptions.ObjectNotFoundException)
+        {
+            return false;
+        }
+    }
+
+    public async Task<IEnumerable<string>> ListFilesAsync(string bucket)
+    {
+        var results = new List<string>();
+        var args = new ListObjectsArgs()
+            .WithBucket(bucket)
+            .WithRecursive(true);
+        await foreach (var item in _client.ListObjectsEnumAsync(args))
+        {
+            results.Add(item.Key);
+        }
+        return results;
+    }
+
+    public async Task CreateBucketIfNotExistsAsync(string bucket)
+    {
+        var existsArgs = new BucketExistsArgs().WithBucket(bucket);
+        bool exists = await _client.BucketExistsAsync(existsArgs);
+        if (!exists)
+        {
+            var makeArgs = new MakeBucketArgs().WithBucket(bucket);
+            await _client.MakeBucketAsync(makeArgs);
+        }
+    }
+}

--- a/Server.Api/Server.Api/appsettings.Development.json
+++ b/Server.Api/Server.Api/appsettings.Development.json
@@ -7,5 +7,11 @@
   },
   "EmailSettings": {
     "DevTo": "dev@example.com"
+  },
+  "Minio": {
+    "Endpoint": "localhost:9000",
+    "AccessKey": "minio",
+    "SecretKey": "minio123",
+    "UseSSL": false
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '3.8'
 services:
   db:
     # Используем официальную сборку PostGIS для поддержки расширения postgis
@@ -34,7 +35,21 @@ services:
     ports:
       - "5002:80"
 
+  minio:
+    image: minio/minio
+    container_name: minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
+    volumes:
+      - minio_data:/data
+    command: server /data --console-address ":9001"
+
   # vector-db and python agent removed; document classification handled by ASP.NET API
 
 volumes:
   pgdata:
+  minio_data:


### PR DESCRIPTION
## Summary
- include MinIO service in docker-compose
- configure MinIO connection settings
- add Minio package
- implement `MinioService` with basic bucket and object operations
- expose API endpoints via `FileController`
- register `MinioService` in DI

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685d171b25988323a6b61a4e0bed8515