### PR TITLE
Add missing manage buttons for departments and positions

### DIFF
--- a/Client.Wasm/Client.Wasm/DTOs/CreateDepartmentDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/CreateDepartmentDto.cs
@@ -1,0 +1,8 @@
+namespace Client.Wasm.DTOs;
+
+public class CreateDepartmentDto
+{
+    public string Name { get; set; } = string.Empty;
+    public int? ParentDepartmentId { get; set; }
+    public string? Description { get; set; }
+}

--- a/Client.Wasm/Client.Wasm/DTOs/CreatePositionDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/CreatePositionDto.cs
@@ -1,0 +1,8 @@
+namespace Client.Wasm.DTOs;
+
+public class CreatePositionDto
+{
+    public string Name { get; set; } = string.Empty;
+    public int DepartmentId { get; set; }
+    public int StaffLimit { get; set; }
+}

--- a/Client.Wasm/Client.Wasm/DTOs/UpdateDepartmentDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/UpdateDepartmentDto.cs
@@ -1,0 +1,8 @@
+namespace Client.Wasm.DTOs;
+
+public class UpdateDepartmentDto
+{
+    public string Name { get; set; } = string.Empty;
+    public int? ParentDepartmentId { get; set; }
+    public string? Description { get; set; }
+}

--- a/Client.Wasm/Client.Wasm/DTOs/UpdatePositionDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/UpdatePositionDto.cs
@@ -1,0 +1,8 @@
+namespace Client.Wasm.DTOs;
+
+public class UpdatePositionDto
+{
+    public string Name { get; set; } = string.Empty;
+    public int DepartmentId { get; set; }
+    public int StaffLimit { get; set; }
+}

--- a/Client.Wasm/Client.Wasm/Pages/DepartmentEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/DepartmentEdit.razor
@@ -1,0 +1,70 @@
+@attribute [Authorize]
+@using Client.Wasm.DTOs
+@inject IDepartmentApiClient ApiClient
+
+<MudDialog @bind-Visible="open" MaxWidth="MaxWidth.Small">
+    <DialogContent>
+        <MudText Typo="Typo.h6" Class="mb-2">@header</MudText>
+        <EditForm Model="model">
+            <MudTextField @bind-Value="model.Name" Label="Название" Class="mb-3 w-100" />
+            <MudNumericField T="int?" @bind-Value="model.ParentDepartmentId" Label="ID родителя" Class="mb-3 w-100" />
+            <MudTextField @bind-Value="model.Description" Label="Описание" Lines="3" Class="mb-3 w-100" />
+            <div class="text-right mt-3">
+                <MudButton Color="Color.Primary" OnClick="Save" Class="me-2">Сохранить</MudButton>
+                <MudButton Variant="Variant.Text" OnClick="Hide">Отмена</MudButton>
+            </div>
+        </EditForm>
+    </DialogContent>
+</MudDialog>
+
+@code {
+    bool open;
+    CreateDepartmentDto model = new();
+    string header = string.Empty;
+    int editId;
+
+    public void Show(CreateDepartmentDto dto)
+    {
+        model = dto;
+        header = "Новый отдел";
+        editId = 0;
+        open = true;
+    }
+
+    public async void Load(int id, DepartmentDto dto)
+    {
+        model = new CreateDepartmentDto
+        {
+            Name = dto.Name,
+            ParentDepartmentId = dto.ParentDepartmentId,
+            Description = dto.Description
+        };
+        header = $"Редактировать отдел #{id}";
+        editId = id;
+        open = true;
+    }
+
+    async Task Save()
+    {
+        if (editId == 0)
+        {
+            await ApiClient.CreateAsync(model);
+        }
+        else
+        {
+            await ApiClient.UpdateAsync(editId, new UpdateDepartmentDto
+            {
+                Name = model.Name,
+                ParentDepartmentId = model.ParentDepartmentId,
+                Description = model.Description
+            });
+        }
+        Hide();
+        if (OnSaved.HasDelegate)
+            await OnSaved.InvokeAsync();
+    }
+
+    void Hide() => open = false;
+
+    [Parameter] public EventCallback OnSaved { get; set; }
+}

--- a/Client.Wasm/Client.Wasm/Pages/DepartmentHierarchy.razor
+++ b/Client.Wasm/Client.Wasm/Pages/DepartmentHierarchy.razor
@@ -8,6 +8,7 @@
         <MudText Typo="Typo.h5">Подразделения</MudText>
     </MudCardHeader>
     <MudCardContent>
+        <MudButton Color="Color.Primary" Class="mb-3" OnClick="@(()=> editDialog.Show(new CreateDepartmentDto()))">Добавить отдел</MudButton>
         <!-- TODO: заменить на MudTreeGrid при необходимости -->
         <MudTable Items="@items" Dense="true" Hover="true">
             <HeaderContent>
@@ -22,11 +23,16 @@
     </MudCardContent>
 </MudCard>
 
+<DepartmentEdit @ref="editDialog" OnSaved="Reload" />
+
 @code {
     List<DepartmentDto> items = new();
+    DepartmentEdit? editDialog;
 
     protected override async Task OnInitializedAsync()
     {
-        items = await ApiClient.GetAllAsync();
+        await Reload();
     }
+
+    async Task Reload() => items = await ApiClient.GetAllAsync();
 }

--- a/Client.Wasm/Client.Wasm/Pages/PositionEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/PositionEdit.razor
@@ -1,0 +1,70 @@
+@attribute [Authorize]
+@using Client.Wasm.DTOs
+@inject IPositionApiClient ApiClient
+
+<MudDialog @bind-Visible="open" MaxWidth="MaxWidth.Small">
+    <DialogContent>
+        <MudText Typo="Typo.h6" Class="mb-2">@header</MudText>
+        <EditForm Model="model">
+            <MudTextField @bind-Value="model.Name" Label="Название" Class="mb-3 w-100" />
+            <MudNumericField T="int" @bind-Value="model.DepartmentId" Label="ID отдела" Class="mb-3 w-100" />
+            <MudNumericField T="int" @bind-Value="model.StaffLimit" Label="Штат" Class="mb-3 w-100" />
+            <div class="text-right mt-3">
+                <MudButton Color="Color.Primary" OnClick="Save" Class="me-2">Сохранить</MudButton>
+                <MudButton Variant="Variant.Text" OnClick="Hide">Отмена</MudButton>
+            </div>
+        </EditForm>
+    </DialogContent>
+</MudDialog>
+
+@code {
+    bool open;
+    CreatePositionDto model = new();
+    string header = string.Empty;
+    int editId;
+
+    public void Show(CreatePositionDto dto)
+    {
+        model = dto;
+        header = "Новая должность";
+        editId = 0;
+        open = true;
+    }
+
+    public async void Load(int id, PositionDto dto)
+    {
+        model = new CreatePositionDto
+        {
+            Name = dto.Name,
+            DepartmentId = dto.DepartmentId,
+            StaffLimit = dto.StaffLimit
+        };
+        header = $"Редактировать должность #{id}";
+        editId = id;
+        open = true;
+    }
+
+    async Task Save()
+    {
+        if (editId == 0)
+        {
+            await ApiClient.CreateAsync(model);
+        }
+        else
+        {
+            await ApiClient.UpdateAsync(editId, new UpdatePositionDto
+            {
+                Name = model.Name,
+                DepartmentId = model.DepartmentId,
+                StaffLimit = model.StaffLimit
+            });
+        }
+        Hide();
+        if (OnSaved.HasDelegate)
+            await OnSaved.InvokeAsync();
+    }
+
+    void Hide() => open = false;
+
+    [Parameter] public EventCallback OnSaved { get; set; }
+}

--- a/Client.Wasm/Client.Wasm/Pages/Positions.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Positions.razor
@@ -8,6 +8,7 @@
         <MudText Typo="Typo.h6">Должности</MudText>
     </MudCardHeader>
     <MudCardContent>
+        <MudButton Color="Color.Primary" Class="mb-3" OnClick="@(()=> editDialog.Show(new CreatePositionDto()))">Добавить должность</MudButton>
         <MudTable Items="@items" Hover="true" Dense="true">
             <HeaderContent>
                 <MudTh>Название</MudTh>
@@ -23,11 +24,16 @@
     </MudCardContent>
 </MudCard>
 
+<PositionEdit @ref="editDialog" OnSaved="Reload" />
+
 @code {
     List<PositionDto> items = new();
+    PositionEdit? editDialog;
 
     protected override async Task OnInitializedAsync()
     {
-        items = await ApiClient.GetAllAsync();
+        await Reload();
     }
+
+    async Task Reload() => items = await ApiClient.GetAllAsync();
 }

--- a/Client.Wasm/Client.Wasm/Services/DepartmentApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/DepartmentApiClient.cs
@@ -7,6 +7,8 @@ using Client.Wasm.Helpers;
 public interface IDepartmentApiClient
 {
     Task<List<DepartmentDto>> GetAllAsync();
+    Task<DepartmentDto> CreateAsync(CreateDepartmentDto dto);
+    Task UpdateAsync(int id, UpdateDepartmentDto dto);
 }
 
 public class DepartmentApiClient : IDepartmentApiClient
@@ -22,5 +24,18 @@ public class DepartmentApiClient : IDepartmentApiClient
     {
         var result = await _http.GetFromJsonSafeAsync<List<DepartmentDto>>("api/departments");
         return result ?? new();
+    }
+
+    public async Task<DepartmentDto> CreateAsync(CreateDepartmentDto dto)
+    {
+        var response = await _http.PostAsJsonAsync("api/departments", dto);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<DepartmentDto>())!;
+    }
+
+    public async Task UpdateAsync(int id, UpdateDepartmentDto dto)
+    {
+        var response = await _http.PutAsJsonAsync($"api/departments/{id}", dto);
+        response.EnsureSuccessStatusCode();
     }
 }

--- a/Client.Wasm/Client.Wasm/Services/PositionApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/PositionApiClient.cs
@@ -7,6 +7,8 @@ using Client.Wasm.Helpers;
 public interface IPositionApiClient
 {
     Task<List<PositionDto>> GetAllAsync();
+    Task<PositionDto> CreateAsync(CreatePositionDto dto);
+    Task UpdateAsync(int id, UpdatePositionDto dto);
 }
 
 public class PositionApiClient : IPositionApiClient
@@ -22,5 +24,18 @@ public class PositionApiClient : IPositionApiClient
     {
         var result = await _http.GetFromJsonSafeAsync<List<PositionDto>>("api/positions");
         return result ?? new();
+    }
+
+    public async Task<PositionDto> CreateAsync(CreatePositionDto dto)
+    {
+        var response = await _http.PostAsJsonAsync("api/positions", dto);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<PositionDto>())!;
+    }
+
+    public async Task UpdateAsync(int id, UpdatePositionDto dto)
+    {
+        var response = await _http.PutAsJsonAsync($"api/positions/{id}", dto);
+        response.EnsureSuccessStatusCode();
     }
 }

--- a/Server.Api/Server.Api/Controllers/DepartmentsController.cs
+++ b/Server.Api/Server.Api/Controllers/DepartmentsController.cs
@@ -20,4 +20,18 @@ public class DepartmentsController : ControllerBase
         var items = await _service.GetAllAsync();
         return Ok(items);
     }
+
+    [HttpPost]
+    public async Task<ActionResult<DepartmentDto>> Create(CreateDepartmentDto dto)
+    {
+        var created = await _service.CreateAsync(dto);
+        return CreatedAtAction(nameof(Get), new { }, created);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Update(int id, UpdateDepartmentDto dto)
+    {
+        await _service.UpdateAsync(id, dto);
+        return NoContent();
+    }
 }

--- a/Server.Api/Server.Api/Controllers/PositionsController.cs
+++ b/Server.Api/Server.Api/Controllers/PositionsController.cs
@@ -20,4 +20,18 @@ public class PositionsController : ControllerBase
         var items = await _service.GetAllAsync();
         return Ok(items);
     }
+
+    [HttpPost]
+    public async Task<ActionResult<PositionDto>> Create(CreatePositionDto dto)
+    {
+        var created = await _service.CreateAsync(dto);
+        return CreatedAtAction(nameof(Get), new { }, created);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Update(int id, UpdatePositionDto dto)
+    {
+        await _service.UpdateAsync(id, dto);
+        return NoContent();
+    }
 }

--- a/Server.Api/Server.Api/DTOs/CreateDepartmentDto.cs
+++ b/Server.Api/Server.Api/DTOs/CreateDepartmentDto.cs
@@ -1,0 +1,8 @@
+namespace GovServices.Server.DTOs;
+
+public class CreateDepartmentDto
+{
+    public string Name { get; set; } = string.Empty;
+    public int? ParentDepartmentId { get; set; }
+    public string? Description { get; set; }
+}

--- a/Server.Api/Server.Api/DTOs/UpdateDepartmentDto.cs
+++ b/Server.Api/Server.Api/DTOs/UpdateDepartmentDto.cs
@@ -1,0 +1,8 @@
+namespace GovServices.Server.DTOs;
+
+public class UpdateDepartmentDto
+{
+    public string Name { get; set; } = string.Empty;
+    public int? ParentDepartmentId { get; set; }
+    public string? Description { get; set; }
+}

--- a/Server.Api/Server.Api/Interfaces/IDepartmentService.cs
+++ b/Server.Api/Server.Api/Interfaces/IDepartmentService.cs
@@ -5,4 +5,6 @@ namespace GovServices.Server.Interfaces;
 public interface IDepartmentService
 {
     Task<List<DepartmentDto>> GetAllAsync();
+    Task<DepartmentDto> CreateAsync(CreateDepartmentDto dto);
+    Task UpdateAsync(int id, UpdateDepartmentDto dto);
 }

--- a/Server.Api/Server.Api/Interfaces/IPositionService.cs
+++ b/Server.Api/Server.Api/Interfaces/IPositionService.cs
@@ -5,4 +5,6 @@ namespace GovServices.Server.Interfaces;
 public interface IPositionService
 {
     Task<List<PositionDto>> GetAllAsync();
+    Task<PositionDto> CreateAsync(CreatePositionDto dto);
+    Task UpdateAsync(int id, UpdatePositionDto dto);
 }

--- a/Server.Api/Server.Api/Mappings/MappingProfile.cs
+++ b/Server.Api/Server.Api/Mappings/MappingProfile.cs
@@ -117,6 +117,8 @@ namespace GovServices.Server.Mappings
             CreateMap<Dictionary, DictionaryDto>();
 
             CreateMap<Department, DepartmentDto>().ReverseMap();
+            CreateMap<CreateDepartmentDto, Department>();
+            CreateMap<UpdateDepartmentDto, Department>();
             CreateMap<PositionEntity, PositionDto>().ReverseMap();
             CreateMap<CreatePositionDto, PositionEntity>();
             CreateMap<UpdatePositionDto, PositionEntity>();

--- a/Server.Api/Server.Api/Services/DepartmentService.cs
+++ b/Server.Api/Server.Api/Services/DepartmentService.cs
@@ -1,6 +1,7 @@
 using GovServices.Server.Data;
 using GovServices.Server.DTOs;
 using GovServices.Server.Interfaces;
+using GovServices.Server.Entities;
 using AutoMapper;
 using Microsoft.EntityFrameworkCore;
 
@@ -21,5 +22,21 @@ public class DepartmentService : IDepartmentService
     {
         var entities = await _context.Departments.ToListAsync();
         return _mapper.Map<List<DepartmentDto>>(entities);
+    }
+
+    public async Task<DepartmentDto> CreateAsync(CreateDepartmentDto dto)
+    {
+        var entity = _mapper.Map<Department>(dto);
+        _context.Departments.Add(entity);
+        await _context.SaveChangesAsync();
+        return _mapper.Map<DepartmentDto>(entity);
+    }
+
+    public async Task UpdateAsync(int id, UpdateDepartmentDto dto)
+    {
+        var entity = await _context.Departments.FindAsync(id);
+        if (entity == null) throw new KeyNotFoundException();
+        _mapper.Map(dto, entity);
+        await _context.SaveChangesAsync();
     }
 }

--- a/Server.Api/Server.Api/Services/PositionService.cs
+++ b/Server.Api/Server.Api/Services/PositionService.cs
@@ -1,6 +1,7 @@
 using GovServices.Server.Data;
 using GovServices.Server.DTOs;
 using GovServices.Server.Interfaces;
+using GovServices.Server.Entities;
 using AutoMapper;
 using Microsoft.EntityFrameworkCore;
 
@@ -21,5 +22,21 @@ public class PositionService : IPositionService
     {
         var entities = await _context.Positions.ToListAsync();
         return _mapper.Map<List<PositionDto>>(entities);
+    }
+
+    public async Task<PositionDto> CreateAsync(CreatePositionDto dto)
+    {
+        var entity = _mapper.Map<Position>(dto);
+        _context.Positions.Add(entity);
+        await _context.SaveChangesAsync();
+        return _mapper.Map<PositionDto>(entity);
+    }
+
+    public async Task UpdateAsync(int id, UpdatePositionDto dto)
+    {
+        var entity = await _context.Positions.FindAsync(id);
+        if (entity == null) throw new KeyNotFoundException();
+        _mapper.Map(dto, entity);
+        await _context.SaveChangesAsync();
     }
 }


### PR DESCRIPTION
## Summary
- add CRUD API support for departments and positions
- expose department and position creation endpoints via new API clients
- add DepartmentEdit and PositionEdit components with add buttons
- refresh pages to use new dialogs
- create missing DTOs

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685d210ba3448323ab45b2fa54813a51