### PR TITLE
Implement subject registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,15 @@ curl -X POST http://localhost:5001/api/classify \
 curl -X POST http://localhost:5001/api/classify \
      -F file=@passport.pdf
 ```
+
+### Реестры субъектов
+
+API предоставляет конечные точки для получения списков физических и юридических лиц.
+
+```bash
+# Физические лица
+curl http://localhost:5001/api/subjects/individuals
+
+# Юридические лица
+curl http://localhost:5001/api/subjects/legal-entities
+```

--- a/Server.Api/Server.Api/Controllers/SubjectsController.cs
+++ b/Server.Api/Server.Api/Controllers/SubjectsController.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+using GovServices.Server.DTOs;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class SubjectsController : ControllerBase
+{
+    private readonly ISubjectService _service;
+
+    public SubjectsController(ISubjectService service)
+    {
+        _service = service;
+    }
+
+    [Authorize]
+    [HttpGet("individuals")]
+    public async Task<ActionResult<List<IndividualDto>>> GetIndividuals()
+    {
+        var items = await _service.GetIndividualsAsync();
+        return Ok(items);
+    }
+
+    [Authorize]
+    [HttpGet("legal-entities")]
+    public async Task<ActionResult<List<LegalEntityDto>>> GetLegalEntities()
+    {
+        var items = await _service.GetLegalEntitiesAsync();
+        return Ok(items);
+    }
+}

--- a/Server.Api/Server.Api/DTOs/IndividualDto.cs
+++ b/Server.Api/Server.Api/DTOs/IndividualDto.cs
@@ -1,0 +1,9 @@
+namespace GovServices.Server.DTOs;
+
+public class IndividualDto
+{
+    public int Id { get; set; }
+    public string FullName { get; set; } = string.Empty;
+    public string? IdentificationNumber { get; set; }
+    public string? Address { get; set; }
+}

--- a/Server.Api/Server.Api/DTOs/LegalEntityDto.cs
+++ b/Server.Api/Server.Api/DTOs/LegalEntityDto.cs
@@ -1,0 +1,9 @@
+namespace GovServices.Server.DTOs;
+
+public class LegalEntityDto
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? TaxId { get; set; }
+    public string? Address { get; set; }
+}

--- a/Server.Api/Server.Api/Data/ApplicationDbContext.cs
+++ b/Server.Api/Server.Api/Data/ApplicationDbContext.cs
@@ -46,6 +46,8 @@ namespace GovServices.Server.Data
         public DbSet<NumberTemplate> NumberTemplates { get; set; }
         public DbSet<NumberTemplateCounter> NumberTemplateCounters { get; set; }
         public DbSet<ErrorReport> ErrorReports { get; set; }
+        public DbSet<Individual> Individuals { get; set; }
+        public DbSet<LegalEntity> LegalEntities { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -197,6 +199,44 @@ namespace GovServices.Server.Data
                     Role = SeedData.Roles.DepartmentHead,
                     ServiceId = SeedData.DefaultServiceId,
                     CanEdit = true
+                }
+            );
+
+            builder.Entity<Individual>().HasData(
+                new Individual
+                {
+                    Id = 1,
+                    FullName = "Иванов Иван Иванович",
+                    IdentificationNumber = "1111 111111",
+                    CreatedAt = createdAt,
+                    UpdatedAt = createdAt
+                },
+                new Individual
+                {
+                    Id = 2,
+                    FullName = "Петров Пётр Петрович",
+                    IdentificationNumber = "2222 222222",
+                    CreatedAt = createdAt,
+                    UpdatedAt = createdAt
+                }
+            );
+
+            builder.Entity<LegalEntity>().HasData(
+                new LegalEntity
+                {
+                    Id = 1,
+                    Name = "ООО Ромашка",
+                    TaxId = "7700000000",
+                    CreatedAt = createdAt,
+                    UpdatedAt = createdAt
+                },
+                new LegalEntity
+                {
+                    Id = 2,
+                    Name = "АО Василёк",
+                    TaxId = "7800000000",
+                    CreatedAt = createdAt,
+                    UpdatedAt = createdAt
                 }
             );
         }

--- a/Server.Api/Server.Api/Entities/Individual.cs
+++ b/Server.Api/Server.Api/Entities/Individual.cs
@@ -1,0 +1,11 @@
+namespace GovServices.Server.Entities;
+
+public class Individual
+{
+    public int Id { get; set; }
+    public string FullName { get; set; } = string.Empty;
+    public string? IdentificationNumber { get; set; }
+    public string? Address { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/Server.Api/Server.Api/Entities/LegalEntity.cs
+++ b/Server.Api/Server.Api/Entities/LegalEntity.cs
@@ -1,0 +1,11 @@
+namespace GovServices.Server.Entities;
+
+public class LegalEntity
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? TaxId { get; set; }
+    public string? Address { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/Server.Api/Server.Api/Interfaces/ISubjectService.cs
+++ b/Server.Api/Server.Api/Interfaces/ISubjectService.cs
@@ -1,0 +1,9 @@
+using GovServices.Server.DTOs;
+
+namespace GovServices.Server.Interfaces;
+
+public interface ISubjectService
+{
+    Task<List<IndividualDto>> GetIndividualsAsync();
+    Task<List<LegalEntityDto>> GetLegalEntitiesAsync();
+}

--- a/Server.Api/Server.Api/Mappings/MappingProfile.cs
+++ b/Server.Api/Server.Api/Mappings/MappingProfile.cs
@@ -130,6 +130,9 @@ namespace GovServices.Server.Mappings
             CreateMap<UpdatePermissionDto, Permission>();
             CreateMap<PageAccess, PageAccessDto>().ReverseMap();
             CreateMap<CreatePageAccessDto, PageAccess>();
+
+            CreateMap<Individual, IndividualDto>().ReverseMap();
+            CreateMap<LegalEntity, LegalEntityDto>().ReverseMap();
         }
 
         private static List<ExecutionStage>? DeserializeStages(string? json)

--- a/Server.Api/Server.Api/Program.cs
+++ b/Server.Api/Server.Api/Program.cs
@@ -138,6 +138,7 @@ builder.Services.AddScoped<IUserProfileService, UserProfileService>();
 builder.Services.AddScoped<IPermissionService, PermissionService>();
 builder.Services.AddScoped<IPageAccessService, PageAccessService>();
 builder.Services.AddSingleton<MinioService>();
+builder.Services.AddScoped<ISubjectService, SubjectService>();
 
 // Регистрация IEmailService (и реализация EmailService)
 builder.Services.AddScoped<IEmailService, EmailService>();

--- a/Server.Api/Server.Api/Services/SubjectService.cs
+++ b/Server.Api/Server.Api/Services/SubjectService.cs
@@ -1,0 +1,31 @@
+using GovServices.Server.Data;
+using GovServices.Server.DTOs;
+using GovServices.Server.Interfaces;
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovServices.Server.Services;
+
+public class SubjectService : ISubjectService
+{
+    private readonly ApplicationDbContext _context;
+    private readonly IMapper _mapper;
+
+    public SubjectService(ApplicationDbContext context, IMapper mapper)
+    {
+        _context = context;
+        _mapper = mapper;
+    }
+
+    public async Task<List<IndividualDto>> GetIndividualsAsync()
+    {
+        var entities = await _context.Individuals.ToListAsync();
+        return _mapper.Map<List<IndividualDto>>(entities);
+    }
+
+    public async Task<List<LegalEntityDto>> GetLegalEntitiesAsync()
+    {
+        var entities = await _context.LegalEntities.ToListAsync();
+        return _mapper.Map<List<LegalEntityDto>>(entities);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `Individual` and `LegalEntity` entities
- expose lists of individuals and legal entities via a new controller
- add DTOs, service and mapping profile entries
- register `SubjectService` in DI
- seed example data and document new endpoints in README

## Testing
- `dotnet build Server.Api/Server.Api/Server.Api.csproj`
- `dotnet test Server.Tests/Server.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_685d24b982f883239d3ce2dab4587014