### PR TITLE
Add mandatory fields to application entity

### DIFF
--- a/Server.Api/Server.Api/DTOs/ApplicationDto.cs
+++ b/Server.Api/Server.Api/DTOs/ApplicationDto.cs
@@ -1,3 +1,5 @@
+using GovServices.Server.Entities;
+
 namespace GovServices.Server.DTOs
 {
     public class ApplicationDto
@@ -6,6 +8,13 @@ namespace GovServices.Server.DTOs
         public string Number { get; set; }
         public int ServiceId { get; set; }
         public string ServiceName { get; set; }
+        public string? ExternalNumber { get; set; }
+        public string ApplicantName { get; set; }
+        public string? RepresentativeName { get; set; }
+        public string Address { get; set; }
+        public ApplicationSource Source { get; set; }
+        public string? RegistrarId { get; set; }
+        public string? RegistrarName { get; set; }
         public int CurrentStepId { get; set; }
         public string CurrentStepName { get; set; }
         public string Status { get; set; }

--- a/Server.Api/Server.Api/DTOs/CreateApplicationDto.cs
+++ b/Server.Api/Server.Api/DTOs/CreateApplicationDto.cs
@@ -1,8 +1,16 @@
+using GovServices.Server.Entities;
+
 namespace GovServices.Server.DTOs
 {
     public class CreateApplicationDto
     {
         public int ServiceId { get; set; }
+        public string? ExternalNumber { get; set; }
+        public string ApplicantName { get; set; } = string.Empty;
+        public string? RepresentativeName { get; set; }
+        public string Address { get; set; } = string.Empty;
+        public ApplicationSource Source { get; set; }
+        public string? RegistrarId { get; set; }
         public Dictionary<string, object> FormData { get; set; }
     }
 }

--- a/Server.Api/Server.Api/Data/ApplicationDbContext.cs
+++ b/Server.Api/Server.Api/Data/ApplicationDbContext.cs
@@ -52,6 +52,16 @@ namespace GovServices.Server.Data
         protected override void OnModelCreating(ModelBuilder builder)
         {
             base.OnModelCreating(builder);
+
+            builder.Entity<Application>()
+                .HasOne(a => a.AssignedTo)
+                .WithMany(u => u.AssignedApplications)
+                .HasForeignKey(a => a.AssignedToUserId);
+
+            builder.Entity<Application>()
+                .HasOne(a => a.Registrar)
+                .WithMany()
+                .HasForeignKey(a => a.RegistrarId);
             builder.Entity<UserPermissionGroup>()
                 .HasKey(upg => new { upg.UserId, upg.PermissionGroupId });
 

--- a/Server.Api/Server.Api/Entities/Application.cs
+++ b/Server.Api/Server.Api/Entities/Application.cs
@@ -4,6 +4,13 @@ namespace GovServices.Server.Entities
     {
         public int Id { get; set; }
         public string Number { get; set; }
+        public string? ExternalNumber { get; set; }
+        public string ApplicantName { get; set; } = string.Empty;
+        public string? RepresentativeName { get; set; }
+        public string Address { get; set; } = string.Empty;
+        public ApplicationSource Source { get; set; }
+        public string? RegistrarId { get; set; }
+        public ApplicationUser? Registrar { get; set; }
         public int ServiceId { get; set; }
         public Service Service { get; set; }
         public int CurrentStepId { get; set; }

--- a/Server.Api/Server.Api/Entities/ApplicationSource.cs
+++ b/Server.Api/Server.Api/Entities/ApplicationSource.cs
@@ -1,0 +1,9 @@
+namespace GovServices.Server.Entities;
+
+public enum ApplicationSource
+{
+    Mfc = 0,
+    EpgU = 1,
+    RpgU = 2,
+    InPerson = 3
+}

--- a/Server.Api/Server.Api/Mappings/MappingProfile.cs
+++ b/Server.Api/Server.Api/Mappings/MappingProfile.cs
@@ -19,6 +19,7 @@ namespace GovServices.Server.Mappings
                 .ForMember(d => d.ServiceName, o => o.MapFrom(s => s.Service != null ? s.Service.Name : null))
                 .ForMember(d => d.CurrentStepName, o => o.MapFrom(s => s.CurrentStep != null ? s.CurrentStep.Name : null))
                 .ForMember(d => d.AssignedToUserName, o => o.MapFrom(s => s.AssignedTo != null ? s.AssignedTo.FullName : null))
+                .ForMember(d => d.RegistrarName, o => o.MapFrom(s => s.Registrar != null ? s.Registrar.FullName : null))
                 .ReverseMap();
 
             CreateMap<CreateApplicationDto, Application>();


### PR DESCRIPTION
## Summary
- extend application entity with fields for external number, applicant, representative, address, source system and registrar
- expose new fields via DTOs and mapping
- map registrar relation in DbContext
- add `ApplicationSource` enum
- ensure .NET 8 is installed and run tests

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685d2afed5348323a57c039294848e6b