### PR TITLE
Add preamble and copies info to orders

### DIFF
--- a/Server.Api/Server.Api/DTOs/CreateOrderDto.cs
+++ b/Server.Api/Server.Api/DTOs/CreateOrderDto.cs
@@ -4,6 +4,7 @@ namespace GovServices.Server.DTOs
     {
         public int? ApplicationId { get; set; }
         public string OrderType { get; set; }
+        public string? Preamble { get; set; }
         public string Text { get; set; }
         public string SignerUserId { get; set; }
     }

--- a/Server.Api/Server.Api/DTOs/OrderDto.cs
+++ b/Server.Api/Server.Api/DTOs/OrderDto.cs
@@ -7,7 +7,9 @@ namespace GovServices.Server.DTOs
         public string OrderType { get; set; }
         public string Number { get; set; }
         public DateTime Date { get; set; }
+        public string? Preamble { get; set; }
         public string Text { get; set; }
+        public string? CopiesTo { get; set; }
         public string SignerUserId { get; set; }
         public string SignerUserName { get; set; }
     }

--- a/Server.Api/Server.Api/DTOs/UpdateOrderDto.cs
+++ b/Server.Api/Server.Api/DTOs/UpdateOrderDto.cs
@@ -2,7 +2,9 @@ namespace GovServices.Server.DTOs
 {
     public class UpdateOrderDto
     {
+        public string? Preamble { get; set; }
         public string Text { get; set; }
+        public string? CopiesTo { get; set; }
         public string SignerUserId { get; set; }
     }
 }

--- a/Server.Api/Server.Api/Entities/Order.cs
+++ b/Server.Api/Server.Api/Entities/Order.cs
@@ -8,7 +8,9 @@ namespace GovServices.Server.Entities
         public string OrderType { get; set; } // "RDZ" или "RDI"
         public string Number { get; set; }
         public DateTime Date { get; set; }
+        public string? Preamble { get; set; }
         public string Text { get; set; }
+        public string? CopiesTo { get; set; }
         public string SignerUserId { get; set; }
         public ApplicationUser Signer { get; set; }
     }

--- a/Server.Api/Server.Api/Migrations/20250627000100_AddOrderFields.cs
+++ b/Server.Api/Server.Api/Migrations/20250627000100_AddOrderFields.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Server.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrderFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CopiesTo",
+                table: "Orders",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Preamble",
+                table: "Orders",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CopiesTo",
+                table: "Orders");
+
+            migrationBuilder.DropColumn(
+                name: "Preamble",
+                table: "Orders");
+        }
+    }
+}

--- a/Server.Api/Server.Api/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Server.Api/Server.Api/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -577,6 +577,9 @@ namespace Server.Api.Migrations
                     b.Property<DateTime>("Date")
                         .HasColumnType("timestamp with time zone");
 
+                    b.Property<string>("Preamble")
+                        .HasColumnType("text");
+
                     b.Property<string>("Number")
                         .IsRequired()
                         .HasColumnType("text");
@@ -590,6 +593,9 @@ namespace Server.Api.Migrations
 
                     b.Property<string>("SignerUserId")
                         .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("CopiesTo")
                         .HasColumnType("text");
 
                     b.Property<string>("Text")

--- a/Server.Api/Server.Api/Services/OrderService.cs
+++ b/Server.Api/Server.Api/Services/OrderService.cs
@@ -50,6 +50,7 @@ public class OrderService : IOrderService
             OrderType = dto.OrderType,
             Number = number,
             Date = DateTime.UtcNow,
+            Preamble = dto.Preamble,
             Text = dto.Text,
             SignerUserId = dto.SignerUserId
         };
@@ -66,7 +67,9 @@ public class OrderService : IOrderService
         if (order == null)
             return false;
 
+        order.Preamble = dto.Preamble;
         order.Text = dto.Text;
+        order.CopiesTo = dto.CopiesTo;
         order.SignerUserId = dto.SignerUserId;
 
         await _db.SaveChangesAsync(cancellationToken);


### PR DESCRIPTION
## Summary
- extend `Order` entity with `Preamble` and `CopiesTo`
- update DTOs and service logic to handle the new fields
- add EF migration and snapshot update

## Testing
- `dotnet build --no-restore`
- `dotnet test Server.Tests/Server.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685d2dd7b05c8323837409f419c5af8b