### PR TITLE
Add migration with application fields

### DIFF
--- a/Server.Api/Server.Api/Migrations/20250628000000_AddApplicationFields.cs
+++ b/Server.Api/Server.Api/Migrations/20250628000000_AddApplicationFields.cs
@@ -1,0 +1,101 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Server.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddApplicationFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ExternalNumber",
+                table: "Applications",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ApplicantName",
+                table: "Applications",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "RepresentativeName",
+                table: "Applications",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Address",
+                table: "Applications",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Source",
+                table: "Applications",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RegistrarId",
+                table: "Applications",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Applications_RegistrarId",
+                table: "Applications",
+                column: "RegistrarId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Applications_AspNetUsers_RegistrarId",
+                table: "Applications",
+                column: "RegistrarId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Applications_AspNetUsers_RegistrarId",
+                table: "Applications");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Applications_RegistrarId",
+                table: "Applications");
+
+            migrationBuilder.DropColumn(
+                name: "ExternalNumber",
+                table: "Applications");
+
+            migrationBuilder.DropColumn(
+                name: "ApplicantName",
+                table: "Applications");
+
+            migrationBuilder.DropColumn(
+                name: "RepresentativeName",
+                table: "Applications");
+
+            migrationBuilder.DropColumn(
+                name: "Address",
+                table: "Applications");
+
+            migrationBuilder.DropColumn(
+                name: "Source",
+                table: "Applications");
+
+            migrationBuilder.DropColumn(
+                name: "RegistrarId",
+                table: "Applications");
+        }
+    }
+}

--- a/Server.Api/Server.Api/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Server.Api/Server.Api/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -49,6 +49,26 @@ namespace Server.Api.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
+                    b.Property<string>("ExternalNumber")
+                        .HasColumnType("text");
+
+                    b.Property<string>("ApplicantName")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("RepresentativeName")
+                        .HasColumnType("text");
+
+                    b.Property<string>("Address")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<int>("Source")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("RegistrarId")
+                        .HasColumnType("text");
+
                     b.Property<int>("ServiceId")
                         .HasColumnType("integer");
 
@@ -66,6 +86,8 @@ namespace Server.Api.Migrations
                     b.HasIndex("CurrentStepId");
 
                     b.HasIndex("ServiceId");
+
+                    b.HasIndex("RegistrarId");
 
                     b.ToTable("Applications");
                 });
@@ -1388,6 +1410,10 @@ namespace Server.Api.Migrations
                         .WithMany("AssignedApplications")
                         .HasForeignKey("AssignedToId");
 
+                    b.HasOne("GovServices.Server.Entities.ApplicationUser", "Registrar")
+                        .WithMany()
+                        .HasForeignKey("RegistrarId");
+
                     b.HasOne("GovServices.Server.Entities.WorkflowStep", "CurrentStep")
                         .WithMany()
                         .HasForeignKey("CurrentStepId")
@@ -1401,6 +1427,8 @@ namespace Server.Api.Migrations
                         .IsRequired();
 
                     b.Navigation("AssignedTo");
+
+                    b.Navigation("Registrar");
 
                     b.Navigation("CurrentStep");
 


### PR DESCRIPTION
## Summary
- create AddApplicationFields EF migration to include missing columns
- update ApplicationDbContext snapshot for new schema

## Testing
- `dotnet build GovServicesSolution.sln`
- `dotnet test GovServicesSolution.sln`


------
https://chatgpt.com/codex/tasks/task_e_685d32216a54832392aaa0e7e4c5cffd