### PR TITLE
Implement workflow designer UI

### DIFF
--- a/Client.Wasm/Client.Wasm/Components/WorkflowStepEdit.razor
+++ b/Client.Wasm/Client.Wasm/Components/WorkflowStepEdit.razor
@@ -1,0 +1,32 @@
+@using Client.Wasm.DTOs
+<MudDialog @bind-Visible="Visible" MaxWidth="MaxWidth.ExtraSmall">
+    <DialogContent>
+        <MudText Typo="Typo.h6" Class="mb-2">@Title</MudText>
+        <MudTextField @bind-Value="Model.Name" Label="Название" Class="mb-2 w-100" />
+        <MudNumericField TValue="int" @bind-Value="Model.Sequence" Label="Порядок" Class="mb-2 w-100" />
+        <div class="text-right">
+            <MudButton Color="Color.Primary" OnClick="Save">Сохранить</MudButton>
+            <MudButton Variant="Variant.Text" OnClick="Cancel">Отмена</MudButton>
+        </div>
+    </DialogContent>
+</MudDialog>
+
+@code {
+    [Parameter] public WorkflowStepDto Model { get; set; } = new();
+    [Parameter] public EventCallback<WorkflowStepDto> OnSave { get; set; }
+    [Parameter] public EventCallback OnCancel { get; set; }
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public string Title { get; set; } = "Шаг";
+
+    async Task Save()
+    {
+        if (OnSave.HasDelegate)
+            await OnSave.InvokeAsync(Model);
+    }
+
+    async Task Cancel()
+    {
+        if (OnCancel.HasDelegate)
+            await OnCancel.InvokeAsync();
+    }
+}

--- a/Client.Wasm/Client.Wasm/Components/WorkflowTransitionEdit.razor
+++ b/Client.Wasm/Client.Wasm/Components/WorkflowTransitionEdit.razor
@@ -1,0 +1,50 @@
+@using Client.Wasm.DTOs
+@using System.Threading
+<MudDialog @bind-Visible="Visible" MaxWidth="MaxWidth.Small">
+    <DialogContent>
+        <MudText Typo="Typo.h6" Class="mb-2">@Title</MudText>
+        <MudSelect T="int" Label="От" Class="mb-2 w-100" @bind-Value="Model.FromStepId">
+            @foreach (var s in Steps)
+            {
+                <MudSelectItem Value="@s.Id">@s.Name</MudSelectItem>
+            }
+        </MudSelect>
+        <MudSelect T="int" Label="К" Class="mb-2 w-100" @bind-Value="Model.ToStepId">
+            @foreach (var s in Steps)
+            {
+                <MudSelectItem Value="@s.Id">@s.Name</MudSelectItem>
+            }
+        </MudSelect>
+        <MudAutocomplete T="string" @bind-Value="Model.ConditionExpression" Label="Условие" Class="mb-2 w-100" Dense="true" SearchFunc="Search" />
+        <div class="text-right">
+            <MudButton Color="Color.Primary" OnClick="Save">Сохранить</MudButton>
+            <MudButton Variant="Variant.Text" OnClick="Cancel">Отмена</MudButton>
+        </div>
+    </DialogContent>
+</MudDialog>
+
+@code {
+    [Parameter] public WorkflowTransitionDto Model { get; set; } = new();
+    [Parameter] public List<WorkflowStepDto> Steps { get; set; } = new();
+    [Parameter] public EventCallback<WorkflowTransitionDto> OnSave { get; set; }
+    [Parameter] public EventCallback OnCancel { get; set; }
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public string Title { get; set; } = "Переход";
+
+    string[] Suggestions = new[] { "context.IsUrgent", "context.UserRole == \"Admin\"" };
+
+    Task<IEnumerable<string>> Search(string value, CancellationToken _)
+        => Task.FromResult(Suggestions.Where(x => x.Contains(value, StringComparison.OrdinalIgnoreCase)) as IEnumerable<string>);
+
+    async Task Save()
+    {
+        if (OnSave.HasDelegate)
+            await OnSave.InvokeAsync(Model);
+    }
+
+    async Task Cancel()
+    {
+        if (OnCancel.HasDelegate)
+            await OnCancel.InvokeAsync();
+    }
+}

--- a/Client.Wasm/Client.Wasm/Pages/WorkflowEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/WorkflowEdit.razor
@@ -1,6 +1,8 @@
 @attribute [Authorize]
 @using Client.Wasm.DTOs
 @using Client.Wasm.Services
+@using Client.Wasm.Components
+@using System.Linq
 @inject IJSRuntime Js
 @inject NavigationManager NavigationManager
 @inject IWorkflowApiClient ApiClient
@@ -18,8 +20,41 @@
                     <MudTextField @bind-Value="model.Name" Label="Название" Class="mb-3 w-100" />
                     <MudTextField @bind-Value="model.Description" Label="Описание" Class="mb-3 w-100" Lines="4" />
                 </MudTabPanel>
-                <MudTabPanel Text="Дополнительно">
-                    <!-- дополнительные поля -->
+                <MudTabPanel Text="Шаги">
+                    <MudButton Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add" OnClick="ShowAddStep" Class="mb-2">Добавить шаг</MudButton>
+                    <MudTable Items="@steps" Hover="true" Dense="true">
+                        <HeaderContent>
+                            <MudTh>Порядок</MudTh>
+                            <MudTh>Название</MudTh>
+                            <MudTh></MudTh>
+                        </HeaderContent>
+                        <RowTemplate Context="step">
+                            <MudTd DataLabel="Порядок">@step.Sequence</MudTd>
+                            <MudTd DataLabel="Название">@step.Name</MudTd>
+                            <MudTd>
+                                <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="@(()=>DeleteStep(step.Id))" />
+                            </MudTd>
+                        </RowTemplate>
+                    </MudTable>
+                </MudTabPanel>
+                <MudTabPanel Text="Переходы">
+                    <MudButton Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add" OnClick="ShowAddTransition" Class="mb-2">Добавить переход</MudButton>
+                    <MudTable Items="@transitions" Hover="true" Dense="true">
+                        <HeaderContent>
+                            <MudTh>От</MudTh>
+                            <MudTh>К</MudTh>
+                            <MudTh>Условие</MudTh>
+                            <MudTh></MudTh>
+                        </HeaderContent>
+                        <RowTemplate Context="tr">
+                            <MudTd DataLabel="От">@GetStepName(tr.FromStepId)</MudTd>
+                            <MudTd DataLabel="К">@GetStepName(tr.ToStepId)</MudTd>
+                            <MudTd DataLabel="Условие">@tr.ConditionExpression</MudTd>
+                            <MudTd>
+                                <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="@(()=>DeleteTransition(tr.Id))" />
+                            </MudTd>
+                        </RowTemplate>
+                    </MudTable>
                 </MudTabPanel>
             </MudTabs>
             <div class="text-right mt-3">
@@ -29,6 +64,8 @@
         </EditForm>
     </DialogContent>
 </MudDialog>
+<WorkflowStepEdit Model="stepModel" Visible="@showStepDialog" Title="Новый шаг" OnSave="OnStepSaved" OnCancel="@(()=>showStepDialog=false)" />
+<WorkflowTransitionEdit Model="transitionModel" Steps="steps" Visible="@showTransitionDialog" Title="Новый переход" OnSave="OnTransitionSaved" OnCancel="@(()=>showTransitionDialog=false)" />
 
 @code {
     bool open;
@@ -36,6 +73,12 @@
     string hdr;
     bool isNew;
     string? errorMessage;
+    List<WorkflowStepDto> steps = new();
+    List<WorkflowTransitionDto> transitions = new();
+    bool showStepDialog;
+    WorkflowStepDto stepModel = new();
+    bool showTransitionDialog;
+    WorkflowTransitionDto transitionModel = new();
 
     public void Show()
     {
@@ -43,6 +86,8 @@
         hdr = "Новый маршрут";
         isNew = true;
         open = true;
+        steps = new();
+        transitions = new();
     }
 
     public async void Load(int id)
@@ -51,6 +96,8 @@
         hdr = $"Редактировать маршрут #{id}";
         isNew = false;
         open = true;
+        steps = await ApiClient.GetStepsAsync(id);
+        transitions = await ApiClient.GetTransitionsAsync(id);
     }
 
     async Task Save()
@@ -65,6 +112,20 @@
             await ApiClient.CreateAsync(model);
         else
             await ApiClient.UpdateAsync(model);
+        foreach (var s in steps)
+        {
+            if (s.Id == 0)
+                await ApiClient.CreateStepAsync(s);
+            else
+                await ApiClient.UpdateStepAsync(s);
+        }
+        foreach (var t in transitions)
+        {
+            if (t.Id == 0)
+                await ApiClient.CreateTransitionAsync(t);
+            else
+                await ApiClient.UpdateTransitionAsync(t);
+        }
         Hide();
         if (OnSaved.HasDelegate)
         {
@@ -73,6 +134,37 @@
     }
 
     void Hide() => open = false;
+
+    void ShowAddStep()
+    {
+        stepModel = new WorkflowStepDto { WorkflowId = model.Id, Sequence = steps.Count + 1 };
+        showStepDialog = true;
+    }
+
+    void ShowAddTransition()
+    {
+        transitionModel = new WorkflowTransitionDto();
+        showTransitionDialog = true;
+    }
+
+    async Task OnStepSaved(WorkflowStepDto dto)
+    {
+        if (dto.Id == 0)
+            steps.Add(dto);
+        showStepDialog = false;
+    }
+
+    async Task OnTransitionSaved(WorkflowTransitionDto dto)
+    {
+        if (dto.Id == 0)
+            transitions.Add(dto);
+        showTransitionDialog = false;
+    }
+
+    void DeleteStep(int id) => steps.RemoveAll(s => s.Id == id);
+    void DeleteTransition(int id) => transitions.RemoveAll(t => t.Id == id);
+
+    string GetStepName(int id) => steps.FirstOrDefault(s => s.Id == id)?.Name ?? "";
 
     [Parameter] public EventCallback OnSaved { get; set; }
 }

--- a/Client.Wasm/Client.Wasm/Services/WorkflowApiClient.cs
+++ b/Client.Wasm/Client.Wasm/Services/WorkflowApiClient.cs
@@ -13,6 +13,16 @@ public interface IWorkflowApiClient
     Task<bool> DeleteAsync(int id);
     Task<bool> CanTransitionAsync(int fromStepId, int toStepId, object? contextData);
     Task<WorkflowStepDto?> GetNextStepAsync(int currentStepId, object? contextData);
+
+    Task<List<WorkflowStepDto>> GetStepsAsync(int workflowId);
+    Task<WorkflowStepDto> CreateStepAsync(WorkflowStepDto dto);
+    Task<bool> UpdateStepAsync(WorkflowStepDto dto);
+    Task<bool> DeleteStepAsync(int id);
+
+    Task<List<WorkflowTransitionDto>> GetTransitionsAsync(int workflowId);
+    Task<WorkflowTransitionDto> CreateTransitionAsync(WorkflowTransitionDto dto);
+    Task<bool> UpdateTransitionAsync(WorkflowTransitionDto dto);
+    Task<bool> DeleteTransitionAsync(int id);
 }
 
 public class WorkflowApiClient : IWorkflowApiClient
@@ -65,5 +75,55 @@ public class WorkflowApiClient : IWorkflowApiClient
         var res = await _http.PostAsJsonAsync($"api/workflow/nextStep/{currentStepId}", contextData);
         if (!res.IsSuccessStatusCode) return null;
         return await res.Content.ReadFromJsonAsync<WorkflowStepDto>();
+    }
+
+    public async Task<List<WorkflowStepDto>> GetStepsAsync(int workflowId)
+    {
+        var res = await _http.GetFromJsonSafeAsync<List<WorkflowStepDto>>($"api/workflowsteps/byWorkflow/{workflowId}");
+        return res ?? new();
+    }
+
+    public async Task<WorkflowStepDto> CreateStepAsync(WorkflowStepDto dto)
+    {
+        var res = await _http.PostAsJsonAsync("api/workflowsteps", dto);
+        res.EnsureSuccessStatusCode();
+        return (await res.Content.ReadFromJsonAsync<WorkflowStepDto>())!;
+    }
+
+    public async Task<bool> UpdateStepAsync(WorkflowStepDto dto)
+    {
+        var res = await _http.PutAsJsonAsync($"api/workflowsteps/{dto.Id}", dto);
+        return res.IsSuccessStatusCode;
+    }
+
+    public async Task<bool> DeleteStepAsync(int id)
+    {
+        var res = await _http.DeleteAsync($"api/workflowsteps/{id}");
+        return res.IsSuccessStatusCode;
+    }
+
+    public async Task<List<WorkflowTransitionDto>> GetTransitionsAsync(int workflowId)
+    {
+        var res = await _http.GetFromJsonSafeAsync<List<WorkflowTransitionDto>>($"api/workflowtransitions/byWorkflow/{workflowId}");
+        return res ?? new();
+    }
+
+    public async Task<WorkflowTransitionDto> CreateTransitionAsync(WorkflowTransitionDto dto)
+    {
+        var res = await _http.PostAsJsonAsync("api/workflowtransitions", dto);
+        res.EnsureSuccessStatusCode();
+        return (await res.Content.ReadFromJsonAsync<WorkflowTransitionDto>())!;
+    }
+
+    public async Task<bool> UpdateTransitionAsync(WorkflowTransitionDto dto)
+    {
+        var res = await _http.PutAsJsonAsync($"api/workflowtransitions/{dto.Id}", dto);
+        return res.IsSuccessStatusCode;
+    }
+
+    public async Task<bool> DeleteTransitionAsync(int id)
+    {
+        var res = await _http.DeleteAsync($"api/workflowtransitions/{id}");
+        return res.IsSuccessStatusCode;
     }
 }

--- a/Server.Api/Server.Api/Controllers/WorkflowStepsController.cs
+++ b/Server.Api/Server.Api/Controllers/WorkflowStepsController.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+using GovServices.Server.DTOs;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class WorkflowStepsController : ControllerBase
+{
+    private readonly IWorkflowService _service;
+
+    public WorkflowStepsController(IWorkflowService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet("byWorkflow/{workflowId}")]
+    public async Task<ActionResult<List<WorkflowStepDto>>> GetByWorkflow(int workflowId)
+    {
+        var list = await _service.GetStepsAsync(workflowId);
+        return Ok(list);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<WorkflowStepDto>> Create(WorkflowStepDto dto)
+    {
+        var created = await _service.CreateStepAsync(dto);
+        return CreatedAtAction(nameof(GetByWorkflow), new { workflowId = created.WorkflowId }, created);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Update(int id, WorkflowStepDto dto)
+    {
+        if (id != dto.Id) return BadRequest();
+        var ok = await _service.UpdateStepAsync(dto);
+        if (!ok) return NotFound();
+        return NoContent();
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var ok = await _service.DeleteStepAsync(id);
+        if (!ok) return NotFound();
+        return NoContent();
+    }
+}

--- a/Server.Api/Server.Api/Controllers/WorkflowTransitionsController.cs
+++ b/Server.Api/Server.Api/Controllers/WorkflowTransitionsController.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Mvc;
+using GovServices.Server.Interfaces;
+using GovServices.Server.DTOs;
+
+namespace GovServices.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class WorkflowTransitionsController : ControllerBase
+{
+    private readonly IWorkflowService _service;
+
+    public WorkflowTransitionsController(IWorkflowService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet("byWorkflow/{workflowId}")]
+    public async Task<ActionResult<List<WorkflowTransitionDto>>> GetByWorkflow(int workflowId)
+    {
+        var list = await _service.GetTransitionsAsync(workflowId);
+        return Ok(list);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<WorkflowTransitionDto>> Create(WorkflowTransitionDto dto)
+    {
+        var created = await _service.CreateTransitionAsync(dto);
+        return CreatedAtAction(nameof(GetByWorkflow), new { workflowId = created.FromStepId }, created);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Update(int id, WorkflowTransitionDto dto)
+    {
+        if (id != dto.Id) return BadRequest();
+        var ok = await _service.UpdateTransitionAsync(dto);
+        if (!ok) return NotFound();
+        return NoContent();
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var ok = await _service.DeleteTransitionAsync(id);
+        if (!ok) return NotFound();
+        return NoContent();
+    }
+}

--- a/Server.Api/Server.Api/Interfaces/IWorkflowService.cs
+++ b/Server.Api/Server.Api/Interfaces/IWorkflowService.cs
@@ -11,4 +11,14 @@ public interface IWorkflowService
     Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default);
     Task<bool> CanTransitionAsync(int fromStepId, int toStepId, object? contextData);
     Task<WorkflowStepDto?> GetNextStepAsync(int currentStepId, object? contextData);
+
+    Task<List<WorkflowStepDto>> GetStepsAsync(int workflowId, CancellationToken cancellationToken = default);
+    Task<WorkflowStepDto> CreateStepAsync(WorkflowStepDto dto, CancellationToken cancellationToken = default);
+    Task<bool> UpdateStepAsync(WorkflowStepDto dto, CancellationToken cancellationToken = default);
+    Task<bool> DeleteStepAsync(int id, CancellationToken cancellationToken = default);
+
+    Task<List<WorkflowTransitionDto>> GetTransitionsAsync(int workflowId, CancellationToken cancellationToken = default);
+    Task<WorkflowTransitionDto> CreateTransitionAsync(WorkflowTransitionDto dto, CancellationToken cancellationToken = default);
+    Task<bool> UpdateTransitionAsync(WorkflowTransitionDto dto, CancellationToken cancellationToken = default);
+    Task<bool> DeleteTransitionAsync(int id, CancellationToken cancellationToken = default);
 }

--- a/Server.Api/Server.Api/Services/WorkflowService.cs
+++ b/Server.Api/Server.Api/Services/WorkflowService.cs
@@ -108,4 +108,82 @@ public class WorkflowService : IWorkflowService
         }
         return null;
     }
+
+    public async Task<List<WorkflowStepDto>> GetStepsAsync(int workflowId, CancellationToken cancellationToken = default)
+    {
+        var steps = await _context.Set<WorkflowStep>()
+            .Where(s => s.WorkflowId == workflowId)
+            .OrderBy(s => s.Sequence)
+            .ToListAsync(cancellationToken);
+        return _mapper.Map<List<WorkflowStepDto>>(steps);
+    }
+
+    public async Task<WorkflowStepDto> CreateStepAsync(WorkflowStepDto dto, CancellationToken cancellationToken = default)
+    {
+        var entity = _mapper.Map<WorkflowStep>(dto);
+        _context.Set<WorkflowStep>().Add(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+        return _mapper.Map<WorkflowStepDto>(entity);
+    }
+
+    public async Task<bool> UpdateStepAsync(WorkflowStepDto dto, CancellationToken cancellationToken = default)
+    {
+        var entity = await _context.Set<WorkflowStep>().FirstOrDefaultAsync(s => s.Id == dto.Id, cancellationToken);
+        if (entity == null)
+            return false;
+        entity.Name = dto.Name;
+        entity.Sequence = dto.Sequence;
+        await _context.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    public async Task<bool> DeleteStepAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var entity = await _context.Set<WorkflowStep>().FirstOrDefaultAsync(s => s.Id == id, cancellationToken);
+        if (entity == null)
+            return false;
+        _context.Remove(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    public async Task<List<WorkflowTransitionDto>> GetTransitionsAsync(int workflowId, CancellationToken cancellationToken = default)
+    {
+        var transitions = await _context.Set<WorkflowTransition>()
+            .Include(t => t.FromStep)
+            .Include(t => t.ToStep)
+            .Where(t => t.FromStep.WorkflowId == workflowId)
+            .ToListAsync(cancellationToken);
+        return _mapper.Map<List<WorkflowTransitionDto>>(transitions);
+    }
+
+    public async Task<WorkflowTransitionDto> CreateTransitionAsync(WorkflowTransitionDto dto, CancellationToken cancellationToken = default)
+    {
+        var entity = _mapper.Map<WorkflowTransition>(dto);
+        _context.Set<WorkflowTransition>().Add(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+        return _mapper.Map<WorkflowTransitionDto>(entity);
+    }
+
+    public async Task<bool> UpdateTransitionAsync(WorkflowTransitionDto dto, CancellationToken cancellationToken = default)
+    {
+        var entity = await _context.Set<WorkflowTransition>().FirstOrDefaultAsync(t => t.Id == dto.Id, cancellationToken);
+        if (entity == null)
+            return false;
+        entity.FromStepId = dto.FromStepId;
+        entity.ToStepId = dto.ToStepId;
+        entity.ConditionExpression = dto.ConditionExpression;
+        await _context.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    public async Task<bool> DeleteTransitionAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var entity = await _context.Set<WorkflowTransition>().FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+        if (entity == null)
+            return false;
+        _context.Remove(entity);
+        await _context.SaveChangesAsync(cancellationToken);
+        return true;
+    }
 }


### PR DESCRIPTION
## Summary
- add controllers and service methods for WorkflowStep and WorkflowTransition CRUD
- extend workflow service interface
- implement workflow designer tabs for steps and transitions
- provide step and transition editing components with autocomplete
- update WorkflowApiClient with new endpoints

## Testing
- `dotnet build GovServicesSolution.sln`
- `dotnet test GovServicesSolution.sln`


------
https://chatgpt.com/codex/tasks/task_e_685d3aa04a548323a59ef83348a16c52