### PR TITLE
Fix null check in workflow transition search

### DIFF
--- a/Client.Wasm/Client.Wasm/Components/WorkflowTransitionEdit.razor
+++ b/Client.Wasm/Client.Wasm/Components/WorkflowTransitionEdit.razor
@@ -33,8 +33,10 @@
 
     string[] Suggestions = new[] { "context.IsUrgent", "context.UserRole == \"Admin\"" };
 
-    Task<IEnumerable<string>> Search(string value, CancellationToken _)
-        => Task.FromResult(Suggestions.Where(x => x.Contains(value, StringComparison.OrdinalIgnoreCase)) as IEnumerable<string>);
+    Task<IEnumerable<string>> Search(string? value, CancellationToken _)
+        => Task.FromResult(Suggestions
+            .Where(x => string.IsNullOrEmpty(value) || x.Contains(value, StringComparison.OrdinalIgnoreCase))
+            as IEnumerable<string>);
 
     async Task Save()
     {


### PR DESCRIPTION
## Summary
- fix search suggestions when `MudAutocomplete` passes a null value

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_685d3d3953088323acaba46bea51aa27