### PR TITLE
Add search and filter controls

### DIFF
--- a/Client.Wasm/Client.Wasm/Pages/Applications.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Applications.razor
@@ -12,6 +12,12 @@
         </MudCardHeader>
         <MudCardContent>
             <MudTextField @bind-Value="searchString" Placeholder="Поиск" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" Class="mb-3" />
+            <MudSelect T="string" @bind-Value="selectedStatus" Label="Статус" Clearable="true" Class="mb-3 ml-4" Dense="true">
+                @foreach (var status in statuses)
+                {
+                    <MudSelectItem Value="@status">@status</MudSelectItem>
+                }
+            </MudSelect>
             <MudButton Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" Class="mb-3" OnClick="OpenNew">Новая заявка</MudButton>
             <MudTable Items="@filteredItems" Hover="true" Dense="true">
                 <HeaderContent>
@@ -45,12 +51,14 @@
     List<ApplicationDto> items = new();
     ApplicationEdit edit;
     string searchString = string.Empty;
-    IEnumerable<ApplicationDto> filteredItems => string.IsNullOrWhiteSpace(searchString)
-        ? items
-        : items.Where(x =>
-            (x.Number != null && x.Number.Contains(searchString, StringComparison.OrdinalIgnoreCase)) ||
-            (x.ServiceName != null && x.ServiceName.Contains(searchString, StringComparison.OrdinalIgnoreCase)) ||
-            (x.Status != null && x.Status.Contains(searchString, StringComparison.OrdinalIgnoreCase)));
+    string selectedStatus;
+    IEnumerable<string> statuses => items.Select(i => i.Status).Where(s => !string.IsNullOrEmpty(s)).Distinct().OrderBy(s => s);
+    IEnumerable<ApplicationDto> filteredItems => items.Where(x =>
+            (string.IsNullOrWhiteSpace(searchString) ||
+                (x.Number != null && x.Number.Contains(searchString, StringComparison.OrdinalIgnoreCase)) ||
+                (x.ServiceName != null && x.ServiceName.Contains(searchString, StringComparison.OrdinalIgnoreCase)) ||
+                (x.Status != null && x.Status.Contains(searchString, StringComparison.OrdinalIgnoreCase))) &&
+            (string.IsNullOrWhiteSpace(selectedStatus) || x.Status == selectedStatus));
 
     protected override async Task OnInitializedAsync() => await LoadData();
     async Task LoadData() => items = await ApiClient.GetAllAsync();

--- a/Client.Wasm/Client.Wasm/Pages/DocumentTemplates.razor
+++ b/Client.Wasm/Client.Wasm/Pages/DocumentTemplates.razor
@@ -11,8 +11,11 @@
             <MudText Typo="Typo.h5">Шаблоны документов</MudText>
         </MudCardHeader>
         <MudCardContent>
-            <MudButton Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" Class="mb-3" OnClick="@(() => editor.Show())">Новый шаблон</MudButton>
-            <MudTable Items="@items" Hover="true" Dense="true">
+            <div class="d-flex mb-3 gap-4 align-items-end">
+                <MudTextField @bind-Value="searchString" Placeholder="Поиск" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" />
+                <MudButton Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" OnClick="@(() => editor.Show())">Новый шаблон</MudButton>
+            </div>
+            <MudTable Items="@filteredItems" Hover="true" Dense="true">
                 <HeaderContent>
                     <MudTh>ID</MudTh>
                     <MudTh>Название</MudTh>
@@ -36,6 +39,9 @@
 @code {
     List<TemplateDto> items = new();
     DocumentTemplateEditor editor;
+    string searchString = string.Empty;
+    IEnumerable<TemplateDto> filteredItems => items.Where(t => string.IsNullOrWhiteSpace(searchString) ||
+        (!string.IsNullOrEmpty(t.Name) && t.Name.Contains(searchString, StringComparison.OrdinalIgnoreCase)));
 
     protected override async Task OnInitializedAsync() => await Load();
 

--- a/Client.Wasm/Client.Wasm/Pages/Orders.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Orders.razor
@@ -9,8 +9,11 @@
             <MudText Typo="Typo.h5">Приказы</MudText>
         </MudCardHeader>
         <MudCardContent>
-            <MudButton Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" Class="mb-3" OnClick="(() => edit.Show(new OrderDto()))">Добавить приказ</MudButton>
-            <MudTable Items="@orders" Hover="true" Dense="true">
+            <div class="d-flex mb-3 gap-4 align-items-end">
+                <MudTextField @bind-Value="searchString" Placeholder="Поиск" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" />
+                <MudButton Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" OnClick="(() => edit.Show(new OrderDto()))">Добавить приказ</MudButton>
+            </div>
+            <MudTable Items="@filteredItems" Hover="true" Dense="true">
                 <HeaderContent>
                     <MudTh>ID</MudTh>
                     <MudTh>Номер</MudTh>
@@ -34,6 +37,10 @@
 @code {
     List<OrderDto> orders = new();
     OrderEdit edit;
+    string searchString = string.Empty;
+    IEnumerable<OrderDto> filteredItems => orders.Where(o =>
+        string.IsNullOrWhiteSpace(searchString) ||
+        (!string.IsNullOrEmpty(o.Number) && o.Number.Contains(searchString, StringComparison.OrdinalIgnoreCase)));
 
     Task Reload() { StateHasChanged(); return Task.CompletedTask; }
 }

--- a/Client.Wasm/Client.Wasm/Pages/Services.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Services.razor
@@ -11,8 +11,17 @@
             <MudText Typo="Typo.h5">Услуги</MudText>
         </MudCardHeader>
         <MudCardContent>
-            <MudButton Color="Color.Primary" Class="mb-3" OnClick="OpenNew">Добавить услугу</MudButton>
-            <MudTable Items="@services" Hover="true" Dense="true">
+            <div class="d-flex mb-3 gap-4 align-items-end">
+                <MudTextField @bind-Value="searchString" Placeholder="Поиск" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" />
+                <MudSelect T="string" @bind-Value="selectedStatus" Label="Статус" Clearable="true" Dense="true">
+                    @foreach (var s in statuses)
+                    {
+                        <MudSelectItem Value="@s">@s</MudSelectItem>
+                    }
+                </MudSelect>
+                <MudButton Color="Color.Primary" OnClick="OpenNew" StartIcon="@Icons.Material.Filled.Add">Добавить услугу</MudButton>
+            </div>
+            <MudTable Items="@filteredItems" Hover="true" Dense="true">
                 <HeaderContent>
                     <MudTh>ID</MudTh>
                     <MudTh>Название</MudTh>
@@ -48,6 +57,14 @@
 @code {
     List<ServiceDto> services;
     ServiceEdit editDialog;
+    string searchString = string.Empty;
+    string selectedStatus;
+    IEnumerable<string> statuses => services.Select(s => s.Status).Where(s => !string.IsNullOrEmpty(s)).Distinct().OrderBy(s => s);
+    IEnumerable<ServiceDto> filteredItems => services.Where(s =>
+            (string.IsNullOrWhiteSpace(searchString) ||
+                (!string.IsNullOrEmpty(s.Name) && s.Name.Contains(searchString, StringComparison.OrdinalIgnoreCase)) ||
+                (!string.IsNullOrEmpty(s.Description) && s.Description.Contains(searchString, StringComparison.OrdinalIgnoreCase))) &&
+            (string.IsNullOrWhiteSpace(selectedStatus) || s.Status == selectedStatus));
 
     protected override async Task OnInitializedAsync()
     {

--- a/Client.Wasm/Client.Wasm/Pages/Users.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Users.razor
@@ -11,8 +11,17 @@
             <MudText Typo="Typo.h5">Пользователи</MudText>
         </MudCardHeader>
         <MudCardContent>
-            <MudButton Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" Class="mb-3" OnClick="@(()=> edit.Show(new CreateUserDto()))">Добавить пользователя</MudButton>
-            <MudTable Items="@items" Hover="true" Dense="true">
+            <div class="d-flex mb-3 gap-4 align-items-end">
+                <MudTextField @bind-Value="searchString" Placeholder="Поиск" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" />
+                <MudSelect T="string" @bind-Value="selectedRole" Label="Роль" Clearable="true" Dense="true">
+                    @foreach (var role in roles)
+                    {
+                        <MudSelectItem Value="@role">@role</MudSelectItem>
+                    }
+                </MudSelect>
+                <MudButton Color="Color.Primary" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" OnClick="@(()=> edit.Show(new CreateUserDto()))">Добавить пользователя</MudButton>
+            </div>
+            <MudTable Items="@filteredItems" Hover="true" Dense="true">
                 <HeaderContent>
                     <MudTh>ID</MudTh>
                     <MudTh>Email</MudTh>
@@ -39,8 +48,23 @@
 @code {
     List<UserDto> items = new();
     UserEdit edit;
+    string searchString = string.Empty;
+    string selectedRole;
+    IEnumerable<string> roles => items.SelectMany(u => u.Roles).Distinct().OrderBy(r => r);
+    IEnumerable<UserDto> filteredItems => items.Where(u =>
+            (string.IsNullOrWhiteSpace(searchString) ||
+                (!string.IsNullOrEmpty(u.Email) && u.Email.Contains(searchString, StringComparison.OrdinalIgnoreCase)) ||
+                (!string.IsNullOrEmpty(u.FullName) && u.FullName.Contains(searchString, StringComparison.OrdinalIgnoreCase))) &&
+            (string.IsNullOrWhiteSpace(selectedRole) || u.Roles.Contains(selectedRole)));
 
     protected override async Task OnInitializedAsync() => await LoadData();
     async Task LoadData() => items = await ApiClient.GetAllAsync();
-    async Task Delete(string id){ if(await Js.InvokeAsync<bool>("confirm", $"Удалить пользователя {id}?")){ await ApiClient.DeleteAsync(id); await LoadData(); } }
+    async Task Delete(string id)
+    {
+        if (await Js.InvokeAsync<bool>("confirm", $"Удалить пользователя {id}?"))
+        {
+            await ApiClient.DeleteAsync(id);
+            await LoadData();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add search/filter UI to Users page
- add status filtering to Services page
- add search box to Orders page
- add search box to Document Templates page

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_685d3fc89eb08323b6ed6372007c756b