### PR TITLE
Fix unused component and update menu

### DIFF
--- a/Client.Wasm/Client.Wasm/Pages/TemplateEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/TemplateEdit.razor
@@ -24,9 +24,11 @@
             </MudTabs>
             <div class="text-right mt-3">
                 <MudButton Type="Button" Color="Color.Primary" Class="me-2" OnClick="Save">Сохранить</MudButton>
+                <MudButton Type="Button" Variant="Variant.Outlined" Class="me-2" OnClick="ShowPreview">Просмотр</MudButton>
                 <MudButton Variant="Variant.Text" OnClick="Hide">Отмена</MudButton>
             </div>
         </EditForm>
+        <DocumentResultViewer @ref="previewer" />
     </DialogContent>
 </MudDialog>
 
@@ -77,5 +79,12 @@
 
     void Hide() => open = false;
 
+    async Task ShowPreview()
+    {
+        await previewer.Show(model.Content);
+    }
+
     [Parameter] public EventCallback OnSaved { get; set; }
+
+    DocumentResultViewer previewer;
 }

--- a/Client.Wasm/Client.Wasm/Services/MenuService.cs
+++ b/Client.Wasm/Client.Wasm/Services/MenuService.cs
@@ -29,6 +29,7 @@ public class MenuService
         AddIfExists(pages, groupStatements.Items, "/registry/applications", "Реестр заявлений");
         AddIfExists(pages, groupStatements.Items, "/registry/rdz-orders", "Распоряжения РДЗ");
         AddIfExists(pages, groupStatements.Items, "/registry/rdi-orders", "Распоряжения РДИ");
+        AddIfExists(pages, groupStatements.Items, "/orders", "Приказы");
         if (groupStatements.Items.Count > 0) Groups.Add(groupStatements);
 
         var groupDocs = new MenuGroup { Title = "📑 Документы" };
@@ -60,6 +61,7 @@ public class MenuService
         AddIfExists(pages, groupSettings.Items, "/document-templates", "Шаблоны документов");
         AddIfExists(pages, groupSettings.Items, "/number-templates", "Шаблоны номеров");
         AddIfExists(pages, groupSettings.Items, "/dictionaries", "Справочники");
+        AddIfExists(pages, groupSettings.Items, "/geoobjects", "Геообъекты");
         if (groupSettings.Items.Count > 0) Groups.Add(groupSettings);
 
         var groupReports = new MenuGroup { Title = "📊 Отчёты" };


### PR DESCRIPTION
## Summary
- enable preview of template content via new button
- link "Приказы" and "Геообъекты" pages in the main menu

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685d42c036548323bcbc4417aaa31c75