### PR TITLE
Fix checkbox generics and nullable dates

### DIFF
--- a/Client.Wasm/Client.Wasm/DTOs/OrderDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/OrderDto.cs
@@ -6,7 +6,7 @@ namespace Client.Wasm.DTOs
         public int? ApplicationId { get; set; }
         public string OrderType { get; set; }
         public string Number { get; set; }
-        public DateTime Date { get; set; }
+        public DateTime? Date { get; set; }
         public string Text { get; set; }
         public string SignerUserId { get; set; }
         public string SignerUserName { get; set; }

--- a/Client.Wasm/Client.Wasm/DTOs/TemplateModel.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/TemplateModel.cs
@@ -6,5 +6,5 @@ public class TemplateModel
     public string ApplicantName { get; set; }
     public string ServiceName { get; set; }
     public string StepName { get; set; }
-    public DateTime Date { get; set; }
+    public DateTime? Date { get; set; }
 }

--- a/Client.Wasm/Client.Wasm/Pages/Orders.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Orders.razor
@@ -23,7 +23,7 @@
                 <RowTemplate>
                     <MudTd DataLabel="ID">@context.Id</MudTd>
                     <MudTd DataLabel="Номер">@context.Number</MudTd>
-                    <MudTd DataLabel="Дата">@context.Date.ToShortDateString()</MudTd>
+                    <MudTd DataLabel="Дата">@(context.Date?.ToShortDateString())</MudTd>
                     <MudTd Class="text-center" DataLabel="">
                         <MudIconButton Icon="@Icons.Material.Filled.Edit" OnClick="@(() => edit.Load(context.Id))" />
                     </MudTd>

--- a/Client.Wasm/Client.Wasm/Pages/Permissions.razor
+++ b/Client.Wasm/Client.Wasm/Pages/Permissions.razor
@@ -42,10 +42,10 @@
             <MudTextField @bind-Value="createModel.Role" Label="Роль" Class="mb-3 w-100" />
             <MudNumericField T="int" @bind-Value="createModel.ServiceId" Label="ID услуги" Class="mb-3 w-100" />
             <MudNumericField T="int" @bind-Value="createModel.DepartmentId" Label="ID отдела" Class="mb-3 w-100" />
-            <MudCheckBox @bind-Checked="createModel.CanView" Label="Просмотр" />
-            <MudCheckBox @bind-Checked="createModel.CanEdit" Label="Изменение" />
-            <MudCheckBox @bind-Checked="createModel.CanApprove" Label="Утверждение" />
-            <MudCheckBox @bind-Checked="createModel.CanDelete" Label="Удаление" />
+            <MudCheckBox T="bool" @bind-Checked="createModel.CanView" Label="Просмотр" />
+            <MudCheckBox T="bool" @bind-Checked="createModel.CanEdit" Label="Изменение" />
+            <MudCheckBox T="bool" @bind-Checked="createModel.CanApprove" Label="Утверждение" />
+            <MudCheckBox T="bool" @bind-Checked="createModel.CanDelete" Label="Удаление" />
             <div class="text-right mt-2">
                 <MudButton Color="Color.Primary" OnClick="Create">Создать</MudButton>
                 <MudButton Variant="Variant.Text" OnClick="()=>dialogOpen=false">Отмена</MudButton>

--- a/Server.Api/Server.Api/DTOs/OrderDto.cs
+++ b/Server.Api/Server.Api/DTOs/OrderDto.cs
@@ -6,7 +6,7 @@ namespace GovServices.Server.DTOs
         public int? ApplicationId { get; set; }
         public string OrderType { get; set; }
         public string Number { get; set; }
-        public DateTime Date { get; set; }
+        public DateTime? Date { get; set; }
         public string? Preamble { get; set; }
         public string Text { get; set; }
         public string? CopiesTo { get; set; }

--- a/Server.Api/Server.Api/Models/TemplateModel.cs
+++ b/Server.Api/Server.Api/Models/TemplateModel.cs
@@ -6,6 +6,6 @@ namespace GovServices.Server.Models
         public string ApplicantName { get; set; }
         public string ServiceName { get; set; }
         public string StepName { get; set; }
-        public DateTime Date { get; set; }
+        public DateTime? Date { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- specify bool generic for `MudCheckBox` components
- make `Date` fields nullable in DTOs
- adjust Orders page for nullable dates

## Testing
- `dotnet build Client.Wasm/Client.Wasm/Client.Wasm.csproj -nologo` *(fails: CS1503 EventCallback conversion errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d589b06b483239f61b1a5eeeee450