### PR TITLE
Fix MudSelect binding generics

### DIFF
--- a/Client.Wasm/Client.Wasm/DTOs/CreatePermissionGroupDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/CreatePermissionGroupDto.cs
@@ -3,5 +3,5 @@ namespace Client.Wasm.DTOs;
 public class CreatePermissionGroupDto
 {
     public string Name { get; set; } = string.Empty;
-    public List<int> PermissionIds { get; set; } = new();
+    public HashSet<int> PermissionIds { get; set; } = new();
 }

--- a/Client.Wasm/Client.Wasm/DTOs/CreateUserDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/CreateUserDto.cs
@@ -8,7 +8,7 @@ namespace Client.Wasm.DTOs
         public string? MiddleName { get; set; }
         public int DepartmentId { get; set; }
         public int PositionId { get; set; }
-        public List<string> RoleIds { get; set; } = new();
-        public List<int> GroupIds { get; set; } = new();
+        public HashSet<string> RoleIds { get; set; } = new();
+        public HashSet<int> GroupIds { get; set; } = new();
     }
 }

--- a/Client.Wasm/Client.Wasm/DTOs/UpdatePermissionGroupDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/UpdatePermissionGroupDto.cs
@@ -3,5 +3,5 @@ namespace Client.Wasm.DTOs;
 public class UpdatePermissionGroupDto
 {
     public string Name { get; set; } = string.Empty;
-    public List<int> PermissionIds { get; set; } = new();
+    public HashSet<int> PermissionIds { get; set; } = new();
 }

--- a/Client.Wasm/Client.Wasm/DTOs/UpdateUserDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/UpdateUserDto.cs
@@ -7,7 +7,7 @@ namespace Client.Wasm.DTOs
         public string? MiddleName { get; set; }
         public int DepartmentId { get; set; }
         public int PositionId { get; set; }
-        public List<string> RoleIds { get; set; } = new();
-        public List<int> GroupIds { get; set; } = new();
+        public HashSet<string> RoleIds { get; set; } = new();
+        public HashSet<int> GroupIds { get; set; } = new();
     }
 }

--- a/Client.Wasm/Client.Wasm/Pages/PermissionGroups.razor
+++ b/Client.Wasm/Client.Wasm/Pages/PermissionGroups.razor
@@ -3,6 +3,7 @@
 @inject IPermissionGroupApiClient Api
 @inject IPermissionApiClient PermApi
 @using Client.Wasm.DTOs
+@using System.Linq
 
 <MudContainer MaxWidth="MaxWidth.False" Class="p-4">
     <MudCard Class="mb-4">
@@ -31,7 +32,7 @@
         <MudText Typo="Typo.h6" Class="mb-2">Новая группа</MudText>
         <EditForm Model="createModel">
             <MudTextField @bind-Value="createModel.Name" Label="Название" Class="mb-3 w-100" />
-            <MudSelect T="int" Label="Права" @bind-SelectedValues="createModel.PermissionIds" MultiSelection="true" Class="mb-3 w-100">
+            <MudSelect T="int" Label="Права" SelectedValues="@createModel.PermissionIds" SelectedValuesChanged="@(values => OnPermissionsChanged(values))" MultiSelection="true" Class="mb-3 w-100">
                 @foreach (var p in permissions)
                 {
                     <MudSelectItem Value="@p.Id">@p.Role</MudSelectItem>
@@ -73,5 +74,11 @@
         await Api.CreateAsync(createModel);
         dialogOpen = false;
         await Load();
+    }
+
+    Task OnPermissionsChanged(IEnumerable<int> values)
+    {
+        createModel.PermissionIds = values.ToHashSet();
+        return Task.CompletedTask;
     }
 }

--- a/Client.Wasm/Client.Wasm/Pages/UserEdit.razor
+++ b/Client.Wasm/Client.Wasm/Pages/UserEdit.razor
@@ -1,5 +1,6 @@
 @attribute [Authorize]
 @using Client.Wasm.DTOs
+@using System.Linq
 @inject IJSRuntime Js
 @inject NavigationManager NavigationManager
 @inject IUserApiClient ApiClient
@@ -27,13 +28,13 @@
                             <MudSelectItem Value="@p.Id">@p.Name</MudSelectItem>
                         }
                     </MudSelect>
-                    <MudSelect T="string" Label="Роли" @bind-SelectedValues="model.RoleIds" MultiSelection="true" Class="mb-3 w-100">
+                    <MudSelect T="string" Label="Роли" SelectedValues="@model.RoleIds" SelectedValuesChanged="@(values => OnRolesChanged(values))" MultiSelection="true" Class="mb-3 w-100">
                         @foreach (var r in allRoles)
                         {
                             <MudSelectItem Value="@r">@r</MudSelectItem>
                         }
                     </MudSelect>
-                    <MudSelect T="int" Label="Группы прав" @bind-SelectedValues="model.GroupIds" MultiSelection="true" Class="mb-3 w-100">
+                    <MudSelect T="int" Label="Группы прав" SelectedValues="@model.GroupIds" SelectedValuesChanged="@(values => OnGroupsChanged(values))" MultiSelection="true" Class="mb-3 w-100">
                         @foreach (var g in groups)
                         {
                             <MudSelectItem Value="@g.Id">@g.Name</MudSelectItem>
@@ -63,7 +64,7 @@
     public async void Show(CreateUserDto dto)
     {
         await LoadDictionaries();
-        model = new CreateUserDto { RoleIds = new List<string>(), GroupIds = new List<int>() };
+        model = new CreateUserDto { RoleIds = new HashSet<string>(), GroupIds = new HashSet<int>() };
         hdr = "Новый пользователь";
         isNew = true;
         open = true;
@@ -82,8 +83,8 @@
             MiddleName = string.Empty,
             DepartmentId = 0,
             PositionId = 0,
-            RoleIds = u.Roles,
-            GroupIds = new List<int>()
+            RoleIds = u.Roles.ToHashSet(),
+            GroupIds = new HashSet<int>()
         };
         hdr = "Редактировать пользователя";
         isNew = false;
@@ -127,6 +128,18 @@
         {
             await OnSaved.InvokeAsync();
         }
+    }
+
+    Task OnRolesChanged(IEnumerable<string> values)
+    {
+        model.RoleIds = values.ToHashSet();
+        return Task.CompletedTask;
+    }
+
+    Task OnGroupsChanged(IEnumerable<int> values)
+    {
+        model.GroupIds = values.ToHashSet();
+        return Task.CompletedTask;
     }
 
     void Hide() => open = false;

--- a/Server.Api/Server.Api/DTOs/CreatePermissionGroupDto.cs
+++ b/Server.Api/Server.Api/DTOs/CreatePermissionGroupDto.cs
@@ -3,5 +3,5 @@ namespace GovServices.Server.DTOs;
 public class CreatePermissionGroupDto
 {
     public string Name { get; set; } = string.Empty;
-    public List<int> PermissionIds { get; set; } = new();
+    public HashSet<int> PermissionIds { get; set; } = new();
 }

--- a/Server.Api/Server.Api/DTOs/CreateUserDto.cs
+++ b/Server.Api/Server.Api/DTOs/CreateUserDto.cs
@@ -8,7 +8,7 @@ namespace GovServices.Server.DTOs
         public string? MiddleName { get; set; }
         public int DepartmentId { get; set; }
         public int PositionId { get; set; }
-        public List<string> RoleIds { get; set; } = new();
-        public List<int> GroupIds { get; set; } = new();
+        public HashSet<string> RoleIds { get; set; } = new();
+        public HashSet<int> GroupIds { get; set; } = new();
     }
 }

--- a/Server.Api/Server.Api/DTOs/UpdatePermissionGroupDto.cs
+++ b/Server.Api/Server.Api/DTOs/UpdatePermissionGroupDto.cs
@@ -3,5 +3,5 @@ namespace GovServices.Server.DTOs;
 public class UpdatePermissionGroupDto
 {
     public string Name { get; set; } = string.Empty;
-    public List<int> PermissionIds { get; set; } = new();
+    public HashSet<int> PermissionIds { get; set; } = new();
 }

--- a/Server.Api/Server.Api/DTOs/UpdateUserDto.cs
+++ b/Server.Api/Server.Api/DTOs/UpdateUserDto.cs
@@ -7,7 +7,7 @@ namespace GovServices.Server.DTOs
         public string? MiddleName { get; set; }
         public int DepartmentId { get; set; }
         public int PositionId { get; set; }
-        public List<string> RoleIds { get; set; } = new();
-        public List<int> GroupIds { get; set; } = new();
+        public HashSet<string> RoleIds { get; set; } = new();
+        public HashSet<int> GroupIds { get; set; } = new();
     }
 }


### PR DESCRIPTION
## Summary
- adjust DTO collection types to use HashSet
- handle MudSelect `SelectedValuesChanged` events with lambdas
- convert incoming enumerable values to HashSet

## Testing
- `dotnet build Client.Wasm/Client.Wasm/Client.Wasm.csproj -c Debug`
- `dotnet build Server.Api/Server.Api/Server.Api.csproj -c Debug`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685d5cfdfcf88323b91d5463e1eda2d2