### PR TITLE
Add tabs to application details page

### DIFF
--- a/Client.Wasm/Client.Wasm/Pages/ApplicationDetails.razor
+++ b/Client.Wasm/Client.Wasm/Pages/ApplicationDetails.razor
@@ -13,68 +13,77 @@
     }
     else
     {
-        <MudCard Class="mb-3">
-            <MudCardHeader>
-                <MudText Typo="Typo.h6">@app.Number</MudText>
-            </MudCardHeader>
-            <MudCardContent>
-                <p><b>Услуга:</b> @app.ServiceName</p>
-                <p><b>Статус:</b> @app.Status</p>
-                <p><b>Создана:</b> @app.CreatedAt.ToShortDateString()</p>
-                <p><b>Обновлена:</b> @app.UpdatedAt.ToShortDateString()</p>
-            </MudCardContent>
-        </MudCard>
-        <MudCard Class="mb-3">
-            <MudCardHeader>
-                <MudText Typo="Typo.h6">Результаты</MudText>
-            </MudCardHeader>
-            <MudCardContent>
-                <MudTable Items="@results" Dense="true">
-                    <HeaderContent>
-                        <MudTh>Тип</MudTh>
-                        <MudTh>Дата</MudTh>
-                        <MudTh>Документ</MudTh>
-                    </HeaderContent>
-                    <RowTemplate>
-                        <MudTd DataLabel="Тип">@context.Type</MudTd>
-                        <MudTd DataLabel="Дата">@context.LinkedAt.ToString("g")</MudTd>
-                        <MudTd DataLabel="Документ">
-                            <a href="/documents/@context.DocumentId" target="_blank">Открыть</a>
-                        </MudTd>
-                    </RowTemplate>
-                </MudTable>
-            </MudCardContent>
-        </MudCard>
+        <MudTabs>
+            <MudTabPanel Text="Основное">
+                <MudCard Class="mb-3">
+                    <MudCardHeader>
+                        <MudText Typo="Typo.h6">@app.Number</MudText>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <p><b>Услуга:</b> @app.ServiceName</p>
+                        <p><b>Статус:</b> @app.Status</p>
+                        <p><b>Создана:</b> @app.CreatedAt.ToShortDateString()</p>
+                        <p><b>Обновлена:</b> @app.UpdatedAt.ToShortDateString()</p>
+                    </MudCardContent>
+                </MudCard>
+            </MudTabPanel>
+            <MudTabPanel Text="Документы">
+                <MudCard Class="mb-3">
+                    <MudCardHeader>
+                        <MudText Typo="Typo.h6">Результаты</MudText>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <MudTable Items="@results" Dense="true">
+                            <HeaderContent>
+                                <MudTh>Тип</MudTh>
+                                <MudTh>Дата</MudTh>
+                                <MudTh>Документ</MudTh>
+                            </HeaderContent>
+                            <RowTemplate>
+                                <MudTd DataLabel="Тип">@context.Type</MudTd>
+                                <MudTd DataLabel="Дата">@context.LinkedAt.ToString("g")</MudTd>
+                                <MudTd DataLabel="Документ">
+                                    <a href="/documents/@context.DocumentId" target="_blank">Открыть</a>
+                                </MudTd>
+                            </RowTemplate>
+                        </MudTable>
+                    </MudCardContent>
+                </MudCard>
 
-        <MudCard Class="mb-3">
-            <MudCardHeader>
-                <div class="d-flex justify-content-between align-items-center">
-                    <MudText Typo="Typo.h6" Class="m-0">Пересмотры</MudText>
-                    <MudButton Variant="Variant.Outlined" OnClick="@(() => revisionModal.Show(app.Id))">Пересмотреть</MudButton>
-                </div>
-            </MudCardHeader>
-            <MudCardContent>
-                <MudTable Items="@revisions" Dense="true">
-                    <HeaderContent>
-                        <MudTh>Тип</MudTh>
-                        <MudTh>Номер</MudTh>
-                        <MudTh>Дата</MudTh>
-                        <MudTh>Документ</MudTh>
-                    </HeaderContent>
-                    <RowTemplate>
-                        <MudTd DataLabel="Тип">@context.Type</MudTd>
-                        <MudTd DataLabel="Номер">@context.DocumentNumber</MudTd>
-                        <MudTd DataLabel="Дата">@context.CreatedAt.ToString("g")</MudTd>
-                        <MudTd DataLabel="Документ">
-                            <a href="@context.SedLink" target="_blank">Ссылка</a>
-                        </MudTd>
-                    </RowTemplate>
-                </MudTable>
-            </MudCardContent>
-        </MudCard>
-
-        <ExternalRequestsTabs ApplicationId="@app.Id" />
-        <RelatedApplicationsTabs appId="@app.Id" />
+                <MudCard Class="mb-3">
+                    <MudCardHeader>
+                        <div class="d-flex justify-content-between align-items-center">
+                            <MudText Typo="Typo.h6" Class="m-0">Пересмотры</MudText>
+                            <MudButton Variant="Variant.Outlined" OnClick="@(() => revisionModal.Show(app.Id))">Пересмотреть</MudButton>
+                        </div>
+                    </MudCardHeader>
+                    <MudCardContent>
+                        <MudTable Items="@revisions" Dense="true">
+                            <HeaderContent>
+                                <MudTh>Тип</MudTh>
+                                <MudTh>Номер</MudTh>
+                                <MudTh>Дата</MudTh>
+                                <MudTh>Документ</MudTh>
+                            </HeaderContent>
+                            <RowTemplate>
+                                <MudTd DataLabel="Тип">@context.Type</MudTd>
+                                <MudTd DataLabel="Номер">@context.DocumentNumber</MudTd>
+                                <MudTd DataLabel="Дата">@context.CreatedAt.ToString("g")</MudTd>
+                                <MudTd DataLabel="Документ">
+                                    <a href="@context.SedLink" target="_blank">Ссылка</a>
+                                </MudTd>
+                            </RowTemplate>
+                        </MudTable>
+                    </MudCardContent>
+                </MudCard>
+            </MudTabPanel>
+            <MudTabPanel Text="Запросы">
+                <ExternalRequestsTabs ApplicationId="@app.Id" />
+            </MudTabPanel>
+            <MudTabPanel Text="Связанные">
+                <RelatedApplicationsTabs appId="@app.Id" />
+            </MudTabPanel>
+        </MudTabs>
 
         <RevisionModal @ref="revisionModal" OnSubmit="AddRevision" />
         <MudButton StartIcon="@Icons.Material.Filled.ArrowBack" Variant="Variant.Text" OnClick="@((MouseEventArgs e) => NavigationManager.NavigateTo("/applications"))">Назад</MudButton>


### PR DESCRIPTION
## Summary
- refactor `ApplicationDetails.razor` into a tabbed layout
- keep documents and revision info under separate "Документы" tab
- add dedicated tab for external requests
- add tab for related applications
- ensure .NET 8 is installed

## Testing
- `dotnet build GovServicesSolution.sln`

------
https://chatgpt.com/codex/tasks/task_e_685d826a41408323a9ae265142208b35