### PR TITLE
Show more details on application page

### DIFF
--- a/Client.Wasm/Client.Wasm/DTOs/ApplicationDto.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/ApplicationDto.cs
@@ -6,6 +6,13 @@ namespace Client.Wasm.DTOs
         public string Number { get; set; }
         public int ServiceId { get; set; }
         public string ServiceName { get; set; }
+        public string? ExternalNumber { get; set; }
+        public string ApplicantName { get; set; }
+        public string? RepresentativeName { get; set; }
+        public string Address { get; set; }
+        public ApplicationSource Source { get; set; }
+        public string? RegistrarId { get; set; }
+        public string? RegistrarName { get; set; }
         public int CurrentStepId { get; set; }
         public string CurrentStepName { get; set; }
         public string Status { get; set; }

--- a/Client.Wasm/Client.Wasm/DTOs/ApplicationSource.cs
+++ b/Client.Wasm/Client.Wasm/DTOs/ApplicationSource.cs
@@ -1,0 +1,9 @@
+namespace Client.Wasm.DTOs;
+
+public enum ApplicationSource
+{
+    Mfc = 0,
+    EpgU = 1,
+    RpgU = 2,
+    InPerson = 3
+}

--- a/Client.Wasm/Client.Wasm/Pages/ApplicationDetails.razor
+++ b/Client.Wasm/Client.Wasm/Pages/ApplicationDetails.razor
@@ -15,17 +15,79 @@
     {
         <MudTabs>
             <MudTabPanel Text="Основное">
-                <MudCard Class="mb-3">
-                    <MudCardHeader>
-                        <MudText Typo="Typo.h6">@app.Number</MudText>
-                    </MudCardHeader>
-                    <MudCardContent>
-                        <p><b>Услуга:</b> @app.ServiceName</p>
-                        <p><b>Статус:</b> @app.Status</p>
-                        <p><b>Создана:</b> @app.CreatedAt.ToShortDateString()</p>
-                        <p><b>Обновлена:</b> @app.UpdatedAt.ToShortDateString()</p>
-                    </MudCardContent>
-                </MudCard>
+                <MudGrid>
+                    <MudItem xs="12" sm="6">
+                        <MudCard Class="mb-3">
+                            <MudCardHeader>
+                                <MudText Typo="Typo.h6">ФИО заявителя</MudText>
+                            </MudCardHeader>
+                            <MudCardContent>
+                                @app.ApplicantName
+                            </MudCardContent>
+                        </MudCard>
+                    </MudItem>
+                    <MudItem xs="12" sm="6">
+                        <MudCard Class="mb-3">
+                            <MudCardHeader>
+                                <MudText Typo="Typo.h6">Номер внутренний</MudText>
+                            </MudCardHeader>
+                            <MudCardContent>
+                                @app.Number
+                            </MudCardContent>
+                        </MudCard>
+                    </MudItem>
+                    <MudItem xs="12" sm="6">
+                        <MudCard Class="mb-3">
+                            <MudCardHeader>
+                                <MudText Typo="Typo.h6">Номер внешний</MudText>
+                            </MudCardHeader>
+                            <MudCardContent>
+                                @app.ExternalNumber
+                            </MudCardContent>
+                        </MudCard>
+                    </MudItem>
+                    <MudItem xs="12" sm="6">
+                        <MudCard Class="mb-3">
+                            <MudCardHeader>
+                                <MudText Typo="Typo.h6">Услуга</MudText>
+                            </MudCardHeader>
+                            <MudCardContent>
+                                @app.ServiceName
+                            </MudCardContent>
+                        </MudCard>
+                    </MudItem>
+                    <MudItem xs="12" sm="6">
+                        <MudCard Class="mb-3">
+                            <MudCardHeader>
+                                <MudText Typo="Typo.h6">Даты</MudText>
+                            </MudCardHeader>
+                            <MudCardContent>
+                                <p><b>Создана:</b> @app.CreatedAt.ToShortDateString()</p>
+                                <p><b>Обновлена:</b> @app.UpdatedAt.ToShortDateString()</p>
+                            </MudCardContent>
+                        </MudCard>
+                    </MudItem>
+                    <MudItem xs="12" sm="6">
+                        <MudCard Class="mb-3">
+                            <MudCardHeader>
+                                <MudText Typo="Typo.h6">Адрес</MudText>
+                            </MudCardHeader>
+                            <MudCardContent>
+                                @app.Address
+                            </MudCardContent>
+                        </MudCard>
+                    </MudItem>
+                    <MudItem xs="12" sm="6">
+                        <MudCard Class="mb-3">
+                            <MudCardHeader>
+                                <MudText Typo="Typo.h6">Источник</MudText>
+                            </MudCardHeader>
+                            <MudCardContent>
+                                @app.Source
+                            </MudCardContent>
+                        </MudCard>
+                    </MudItem>
+                </MudGrid>
             </MudTabPanel>
             <MudTabPanel Text="Документы">
                 <MudCard Class="mb-3">


### PR DESCRIPTION
## Summary
- sync client DTO with backend to include extra application fields
- define `ApplicationSource` enum on the client
- display applicant info, numbers, dates, address and source as separate cards in Application Details page

## Testing
- `dotnet build ./GovServicesSolution.sln`
- `dotnet test ./GovServicesSolution.sln`


------
https://chatgpt.com/codex/tasks/task_e_685e39be92dc83239ef84cf7322eebff